### PR TITLE
Remove -V from docx, html options; add standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,6 @@ tex:
 docx:
 	pandoc $(INPUTDIR)/*.md \
 	-o $(OUTPUTDIR)/thesis.docx \
-	-V fontsize=12pt \
-	-V documentclass:report \
 	--bibliography=$(BIBFILE) \
 	--csl=$(STYLEDIR)/ref_format.csl \
 	--toc
@@ -61,10 +59,10 @@ docx:
 html:
 	pandoc $(INPUTDIR)/*.md \
 	-o $(OUTPUTDIR)/thesis.html \
-	-V fontsize=12pt \
-	-V documentclass:report \
+	--standalone \
 	--bibliography=$(BIBFILE) \
 	--csl=$(STYLEDIR)/ref_format.csl \
-	--toc
+	--toc \
+	--number-sections
 
 .PHONY: help pdf docx html tex


### PR DESCRIPTION
The variable declarations in the Makefile under docx and html are
superfluous, in case of docx because they can't be used and in case of
html because there is no template provided or because "documentclass"
applies only to LaTeX.

The "standalone" option is also needed for the table of contents to show
up in the HTML output.

*Also forgot to mention in the commit message, but I added number-sections option to HTML as well.