### PR TITLE
Add an html template and css styling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,14 @@ html:
 	pandoc $(INPUTDIR)/*.md \
 	-o $(OUTPUTDIR)/thesis.html \
 	--standalone \
+	--template=$(STYLEDIR)/template.html \
 	--bibliography=$(BIBFILE) \
 	--csl=$(STYLEDIR)/ref_format.csl \
+	--include-in-header=$(STYLEDIR)/style.css \
 	--toc \
 	--number-sections
+	rm -rf $(OUTPUTDIR)/source
+	mkdir $(OUTPUTDIR)/source
+	cp -r $(INPUTDIR)/figures $(OUTPUTDIR)/source/figures
 
 .PHONY: help pdf docx html tex

--- a/style/style.css
+++ b/style/style.css
@@ -1,0 +1,133 @@
+<style>
+body {
+    font-family: Georgia;
+    max-width: 800px;
+    margin: 0 auto;
+    line-height: 30px;
+    font-size: 18px;
+    padding-left: 350px;
+    padding-right: 50px;
+    color: #111;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: Arial;
+}
+
+h1 {
+    padding-top: 200px;
+    line-height: 50px;
+}
+h2 {
+    padding-top: 30px;
+}
+h3 {
+    padding-top: 20px;
+}
+h4 {
+    padding-top: 10px;
+}
+p {
+    text-align: justify;
+}
+p a {
+    word-wrap: break-word;
+    white-space: pre;
+}
+code {
+    word-wrap: break-word;
+}
+blockquote {
+    border-left: 3px solid #eee;
+    margin-left: 20px;
+    padding-left: 20px;
+}
+
+::selection {
+    background-color: #E4E4E4;
+}
+
+table {
+    width: 100%;
+}
+table caption {
+    font-weight: bold;
+}
+table tr {
+    padding: 0;
+    margin: 0;
+    background-color: #f0f0f0;
+}
+table tr.even {
+    background-color: #fafafa;
+}
+table td {
+    margin: 0;
+    padding: 3px 5px;
+}
+
+p span.added {
+    color: green;
+    background-color: #FFF3C5;
+}
+p span.removed {
+    color: red;
+    background-color: #FFF3C5;
+}
+
+#title-page {
+    padding: 80px 0;
+}
+
+#TOC {
+    position: fixed;
+    left: 0;
+    top: 0;
+    overflow-y: scroll;
+    height: 100%;
+    background: #fafafa;
+    max-width: 300px;
+    font-family: Arial;
+    font-size: 15px;
+    line-height: 30px;
+}
+::-webkit-scrollbar {
+    width: 8px;
+}
+::-webkit-scrollbar-track {
+    background-color: #ECECEC;
+}
+::-webkit-scrollbar-thumb {
+    background-color: #B0B0B0;
+    border-radius: 8px;
+}
+#TOC > ul {
+    padding-right: 10px;
+}
+#TOC ul {
+    list-style: none;
+    padding-left: 20px;
+}
+#TOC ul li a {
+    text-decoration: none;
+    color: #364149;
+    text-overflow: ellipsis;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+}
+#TOC ul li a:hover {
+    color: #008cff;
+}
+
+.figure {
+    text-align: center;
+}
+.figure p {
+    text-align: center;
+    font-style: italic;
+}
+.figure img {
+      width: 100%;
+}
+</style>

--- a/style/template.html
+++ b/style/template.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="Content-Style-Type" content="text/css" />
+        <meta name="generator" content="pandoc" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+        $for(author-meta)$
+            <meta name="author" content="$author-meta$" />
+        $endfor$
+        $if(date-meta)$
+            <meta name="date" content="$date-meta$" />
+        $endif$
+        <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
+        <style type="text/css">code{white-space: pre;}</style>
+        $if(quotes)$
+            <style type="text/css">q { quotes: "GÇ£" "GÇ¥" "GÇÿ" "GÇÖ"; }</style>
+        $endif$
+        $if(highlighting-css)$
+            <style type="text/css">
+            $highlighting-css$
+            </style>
+        $endif$
+        $for(css)$
+            <link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
+        $endfor$
+        $if(math)$
+            $math$
+        $endif$
+        $for(header-includes)$
+            $header-includes$
+        $endfor$
+        <script src="js/jquery.js"></script>
+        <script src="js/diff.js"></script>
+        <script src="js/main.js"></script>
+    </head>
+    <body>
+        $for(include-before)$
+            $include-before$
+        $endfor$
+        <!--
+        $if(title)$
+            <div id="$idprefix$header">
+                <h1 class="title">$title$</h1>
+                $if(subtitle)$
+                <h1 class="subtitle">$subtitle$</h1>
+                $endif$
+                $for(author)$
+                <h2 class="author">$author$</h2>
+                $endfor$
+                $if(date)$
+                <h3 class="date">$date$</h3>
+                $endif$
+            </div>
+        $endif$
+        -->
+        <div id="title-page">
+            <h1>This is the title of the thesis</h1>
+            <h2>Firstname Surname</h2>
+        </div>
+        $if(toc)$
+            <div id="$idprefix$TOC">
+                $toc$
+            </div>
+        $endif$
+        $if(lof)$
+            <div id="$idprefix$LOF">
+                $lof$
+            </div>
+        $endif$
+        $if(lot)$
+            <div id="$idprefix$LOT">
+                $lot$
+            </div>
+        $endif$
+        $body$
+        $for(include-after)$
+            $include-after$
+        $endfor$
+    </body>
+</html>
+


### PR DESCRIPTION
This pull request adds an html template file and css styling file to improve the html export. The Makefile is edited to reflect this in the pandoc parameters.

*Be aware that the Makefile changes are only tested on Windows, I have no idea if I can use `mkdir, cp, and rm` like that on a Unix system.*

And the export is not perfect, but it is pretty decent:

![image](https://cloud.githubusercontent.com/assets/1388162/7586765/8e525986-f8b0-11e4-9ca7-677a9e7b70c2.png)

