### PR TITLE
Grunt task file to watch markdown files and auto-compile them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ target/
 
 # ignore DS store files
 .DS_Store
+
+# Node modules
+node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,41 @@
+module.exports = function(grunt) {
+
+    var type = grunt.option('type');
+    if(!type) type = 'pdf:html';
+
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        notify: {
+            make: {
+                options: {
+                    message: "Compilation done"
+                }
+            }
+        },
+        watch: {
+            options: {
+                interrupt: true
+            },
+            scripts: {
+                files: ['source/*.md'],
+                tasks: ['make:' + type, 'notify:make']
+            }
+        },
+        notify_hooks: {
+            options: {
+                enabled: true,
+                max_jshint_notifications: 5, // maximum number of notifications from jshint output
+                title: "Thesis compilation", // defaults to the name in package.json, or will use project directory's name
+                success: true, // whether successful grunt executions should be notified automatically
+                duration: 2 // the duration of notification in seconds, for `notify-send only
+            }
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-make');
+    grunt.loadNpmTasks('grunt-notify');
+
+    grunt.registerTask('default', ['make:' + type]);
+};

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Some useful points, in a random order:
 - the template uses [John Macfarlane's Pandoc](http://johnmacfarlane.net/pandoc/README.html) to generate the output documents. Refer to this page for Markdown formatting guidelines.
 - PDFs are generated using the Latex templates in the style directory. Fonts etc can be changed in the tex templates.
 - To change the citation style, just overwrite ref_format.csl with the new style. Style files can be obtained from [citationstyles.org/](http://citationstyles.org/)
+- For fellow web developers, there is a Grunt task file (Gruntfile.js) which can be used to 'watch' the markdown files. By running `$ npm install` and then `$ npm run-script watch` the PDF and HTML export is done automatically when saving a Markdown file.
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "MarkdownThesis",
+  "version": "1.0.0",
+  "scripts": {
+    "watch": "grunt watch"
+  },
+  "dependencies": {
+    "grunt-cli": "^0.1.13",
+    "grunt": "^0.4.5",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-make": "^1.0.0",
+    "grunt-notify": "^0.4.1"
+  }
+}


### PR DESCRIPTION
This pull requests adds a NodeJS NPM package.json file to install the right package to use Grunt. Gruntfile.js defines tasks so that the thesis can be automatically compiled when a Markdown files gets changed in the source folder.

Also adds a line to the README to explain the options slightly.