### PR TITLE
Fix tightlist in pandoc 1.14

### DIFF
--- a/style/template.tex
+++ b/style/template.tex
@@ -5,6 +5,10 @@ $else$
 \usepackage{lmodern}
 $endif$
 
+% fix for pandoc 1.14
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 % TP: hack to truncate list of figures/tables.
 \usepackage{truncate}
 \usepackage{caption}


### PR DESCRIPTION
pandoc 1.14 (current pandoc today) introduced \tightlist

Related links:

https://github.com/jgm/pandoc/pull/1571#issuecomment-106298268
https://github.com/osener/markup.rocks/issues/4
https://github.com/rstudio/rmarkdown/issues/439