### PR TITLE
use Palatino instead of non existing Palatino Linotype

### DIFF
--- a/style/preamble.tex
+++ b/style/preamble.tex
@@ -25,7 +25,7 @@
 \usepackage{xunicode}
 \usepackage{xltxtra}
 \defaultfontfeatures{Mapping=tex-text} % converts LaTeX specials (``quotes'' --- dashes etc.) to unicode
-\setromanfont[Scale=1.01,Ligatures={Common},Numbers={OldStyle}]{Palatino Linotype}
+\setromanfont[Scale=1.01,Ligatures={Common},Numbers={OldStyle}]{Palatino}
 % \setromanfont[Scale=1.01,Ligatures={Common},Numbers={OldStyle}]{Adobe Caslon Pro}
 %Following line controls size of code chunks
 \setmonofont[Scale=0.9]{Monaco} 


### PR DESCRIPTION
I do not know if this is OS (X) specific. I cannot create the PDF when using `Palatino Linotype`.

It works with `Palatino` though (using MacTex).