### PR TITLE
Builds on Travis CI now passing!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,24 @@ branches:
 # Set the language
 language: bash
 
-# Try install Pandoc
-before_install: 
-  - sudo apt-get install pandoc
-  - sudo apt-get install texlive-xetex texlive-latex-recommended texlive-latex-extra 
+# Set the environment path to include Pandoc binaries
+env:
+  global:
+    - PATH=$TRAVIS_BUILD_DIR/usr/bin/:$PATH
+
+before_install:
+  # Fetch pandoc and pandoc-citeproc binaries
+  - wget https://github.com/jgm/pandoc/releases/download/1.15.0.5/pandoc-1.15.0.5-1-amd64.deb && ar p pandoc-1.15.0.5-1-amd64.deb data.tar.gz | tar zx
+  # Install TeX Live
+  - sudo add-apt-repository -y ppa:texlive-backports/ppa
+  - sudo apt-get update -qq
+  - sudo apt-get install texlive-xetex texlive-latex-recommended texlive-latex-extra
   - sudo apt-get install texlive-fonts-recommended texlive-fonts-extra
   - sudo apt-get install texlive-science
+  # Install fonts
+  - sudo apt-get install lmodern
 
 # Attempt to create a PDF
-script: 
+script:
   - make pdf
-  - make html 
+  - make html

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Template for writing a PhD thesis in Markdown
+# Template for writing a PhD thesis in Markdown [![Build Status](https://travis-ci.org/tompollard/phd_thesis_markdown.svg?branch=master)](https://travis-ci.org/tompollard/phd_thesis_markdown)
 
 This repository provides a framework for writing a PhD thesis in Markdown. I used the template for my PhD submission to University College London (UCL), but it should be straightforward to adapt suit other universities too.
 
 ## Why write my thesis in Markdown?
 
-Markdown is a super-friendly plain text format that can be easily converted to a bunch of other formats like PDF, Word and Latex. You'll enjoy working in Markdown because: 
+Markdown is a super-friendly plain text format that can be easily converted to a bunch of other formats like PDF, Word and Latex. You'll enjoy working in Markdown because:
 - it is a clean, plain-text format...
 - ...but you can use Latex when you need it (for example, in laying out mathematical formula).
 - it doesn't suffer from the freezes and crashes that some of us experience when working with large, image-heavy Word documents.
@@ -37,10 +37,10 @@ There are some minor annoyances:
     - A text editor, like [Sublime](https://www.sublimetext.com/), which is what you'll use write the thesis.  
     - Latex, needed for things like styling.  
     - [Pandoc](http://johnmacfarlane.net/pandoc), for converting the Markdown to other formats.  
-    - Git, for version control. 
+    - Git, for version control.
 2. [Fork the repository](https://github.com/tompollard/phd_thesis_markdown/fork) on Github  
 3. Clone the repository onto your local computer (or [download the Zip file](https://github.com/tompollard/phd_thesis_markdown/archive/master.zip)).  
-4. Navigate to the directory that contains the Makefile and type "make pdf" (or "make html") at the command line to update the PDF (or HTML) in the output directory. 
+4. Navigate to the directory that contains the Makefile and type "make pdf" (or "make html") at the command line to update the PDF (or HTML) in the output directory.
 5. Edit the files in the 'source' directory, then goto step 4.  
 
 ## What else do I need to know?
@@ -61,5 +61,3 @@ Contributions to the template are encouraged! There are lots of things that coul
 - improving the style of Word and Tex outputs.
 
 Please fork and edit the project, then send a pull request.
-
-

--- a/style/preamble.tex
+++ b/style/preamble.tex
@@ -3,8 +3,8 @@
 % Table of contents formatting
 \renewcommand{\contentsname}{Table of Contents}
 \setcounter{tocdepth}{3}
- 
-% Headers and page numbering 
+
+% Headers and page numbering
 \usepackage{fancyhdr}
 \pagestyle{plain}
 
@@ -24,7 +24,7 @@
 % \definecolor{gray75}{gray}{0.75}
 % \newcommand{\hsp}{\hspace{20pt}}
 % \titleformat{\chapter}[hang]{\Huge\bfseries}{\thechapter\hsp\textcolor{gray75}{|}\hsp}{0pt}{\Huge\bfseries}
- 
+
 % % Fonts and typesetting
 % \setmainfont[Scale=1.1]{Helvetica}
 % \setsansfont[Scale=1.1]{Verdana}
@@ -33,12 +33,12 @@
 \usepackage{xunicode}
 \usepackage{xltxtra}
 \defaultfontfeatures{Mapping=tex-text} % converts LaTeX specials (``quotes'' --- dashes etc.) to unicode
-\setromanfont[Scale=1.01,Ligatures={Common},Numbers={OldStyle}]{Palatino}
+% \setromanfont[Scale=1.01,Ligatures={Common},Numbers={OldStyle}]{Palatino}
 % \setromanfont[Scale=1.01,Ligatures={Common},Numbers={OldStyle}]{Adobe Caslon Pro}
 %Following line controls size of code chunks
-\setmonofont[Scale=0.9]{Monaco} 
+% \setmonofont[Scale=0.9]{Monaco}
 %Following line controls size of figure legends
-\setsansfont[Scale=1.2]{Optima Regular} 
+% \setsansfont[Scale=1.2]{Optima Regular}
 
 %Attempt to set math size
 %First size must match the text size in the document or command will not work
@@ -46,17 +46,17 @@
 \DeclareMathSizes{12}{13}{13}{13}
 
 % ---- CUSTOM AMPERSAND
-\newcommand{\amper}{{\fontspec[Scale=.95]{Adobe Caslon Pro}\selectfont\itshape\&}}
+% \newcommand{\amper}{{\fontspec[Scale=.95]{Adobe Caslon Pro}\selectfont\itshape\&}}
 
 % HEADINGS
-\usepackage{sectsty} 
-\usepackage[normalem]{ulem} 
-\sectionfont{\rmfamily\mdseries\Large} 
-\subsectionfont{\rmfamily\mdseries\scshape\large} 
-\subsubsectionfont{\rmfamily\bfseries\upshape\large} 
-% \sectionfont{\rmfamily\mdseries\Large} 
-% \subsectionfont{\rmfamily\mdseries\scshape\normalsize} 
-% \subsubsectionfont{\rmfamily\bfseries\upshape\normalsize} 
+\usepackage{sectsty}
+\usepackage[normalem]{ulem}
+\sectionfont{\rmfamily\mdseries\Large}
+\subsectionfont{\rmfamily\mdseries\scshape\large}
+\subsubsectionfont{\rmfamily\bfseries\upshape\large}
+% \sectionfont{\rmfamily\mdseries\Large}
+% \subsectionfont{\rmfamily\mdseries\scshape\normalsize}
+% \subsubsectionfont{\rmfamily\bfseries\upshape\normalsize}
 
 % Set figure legends and captions to be smaller sized sans serif font
 \usepackage[font={footnotesize,sf}]{caption}
@@ -90,7 +90,7 @@
 \newcolumntype{x}[1]{%
 >{\centering\arraybackslash}m{#1}}%
 
-% Allow for long captions and float captions on opposite page of figures 
+% Allow for long captions and float captions on opposite page of figures
 % \usepackage[rightFloats, CaptionBefore]{fltpage}
 
 % Don't let floats cross subsections


### PR DESCRIPTION
Builds on Travis CI are running on Ubuntu 12.04's VM (as of July 2015), so they provide a little outdated version of pandoc and TeX Live. This seems to be one of the issue causing the build to fail.

I've updated the Travis configuration to make use of the latest TeX Live (from the official PPA backports) and the version 1.15.0.5-1 of pandoc.

Some fonts (Palatino, Adobe Caslon, Optima) referenced in the preamble are proprietary fonts. This means they can't be found in the Ubuntu VMs, so I've commented the references to those.

I also tried to make the Travis build runs on container (which might speed up the build), but currently the APT source for the backports of TeX Live is not available. I've submitted a request<sup>1</sup> to add it on the Travis repo.

[1] : https://github.com/travis-ci/travis-ci/issues/4295