### PR TITLE
Enable Grunt notifications options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,7 +26,6 @@ module.exports = function(grunt) {
             options: {
                 enabled: true,
                 max_jshint_notifications: 5, // maximum number of notifications from jshint output
-                title: "Thesis compilation", // defaults to the name in package.json, or will use project directory's name
                 success: true, // whether successful grunt executions should be notified automatically
                 duration: 2 // the duration of notification in seconds, for `notify-send only
             }
@@ -36,6 +35,8 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-make');
     grunt.loadNpmTasks('grunt-notify');
+
+    grunt.task.run('notify_hooks');
 
     grunt.registerTask('default', ['make:' + type]);
 };


### PR DESCRIPTION
The options previously set for grunt-notify weren't enabled. I added `notify_hooks` to the task to be run.
I've also removed the title in the options, the title now used is the one from package.json.

Now, it shows two notifications : 

After the success of the make command : 
<img width="398" alt="screen shot 2015-07-26 at 19 08 44" src="https://cloud.githubusercontent.com/assets/1223876/8894980/d7a3a618-33c9-11e5-912d-51991bf62407.png">

After the success of the grunt execution :
<img width="379" alt="screen shot 2015-07-26 at 19 08 59" src="https://cloud.githubusercontent.com/assets/1223876/8894981/d98bc4c4-33c9-11e5-868d-779b1986acd2.png">

This might be overkill as there is only one task during the grunt execution.