### PR TITLE
LiveReload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,12 +30,35 @@ module.exports = function(grunt) {
                 success: true, // whether successful grunt executions should be notified automatically
                 duration: 2 // the duration of notification in seconds, for `notify-send only
             }
+        },
+        express: {
+            all: {
+                options: {
+                    port: 9000,
+                    hostname: "0.0.0.0",
+                    bases: ['output'], // the directory to serve
+                    livereload: true
+                }
+            }
+        },
+        open: {
+            all: {
+                path: 'http://localhost:<%= express.all.options.port%>/thesis.html'
+            }
         }
     });
 
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-make');
     grunt.loadNpmTasks('grunt-notify');
+    grunt.loadNpmTasks('grunt-open');
+    grunt.loadNpmTasks('grunt-express');
 
     grunt.registerTask('default', ['make:' + type]);
+
+    grunt.registerTask('server', [
+        'express',
+        'open',
+        'watch'
+    ]);
 };

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Some useful points, in a random order:
 - the template uses [John Macfarlane's Pandoc](http://johnmacfarlane.net/pandoc/README.html) to generate the output documents. Refer to this page for Markdown formatting guidelines.
 - PDFs are generated using the Latex templates in the style directory. Fonts etc can be changed in the tex templates.
 - To change the citation style, just overwrite ref_format.csl with the new style. Style files can be obtained from [citationstyles.org/](http://citationstyles.org/)
-- For fellow web developers, there is a Grunt task file (Gruntfile.js) which can be used to 'watch' the markdown files. By running `$ npm install` and then `$ npm run-script watch` the PDF and HTML export is done automatically when saving a Markdown file.
+- For fellow web developers, there is a Grunt task file (Gruntfile.js) which can be used to 'watch' the markdown files. By running `$ npm install` and then `$ npm run watch` the PDF and HTML export is done automatically when saving a Markdown file.
+- You can automatically reload the HTML page on your browser using LiveReload with the command `$ npm run livereload`. The HTML page will automatically reload when saving a Markdown file after the export is done.
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-make": "^1.0.0",
     "grunt-notify": "^0.4.1"
+  },
+  "devDependencies": {
+    "grunt-express": "^1.4.1",
+    "grunt-open": "^0.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "MarkdownThesis",
   "version": "1.0.0",
   "scripts": {
-    "watch": "grunt watch"
+    "watch": "grunt watch",
+    "livereload": "grunt server -type html"
   },
   "dependencies": {
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
This PR adds LiveReload support for the HTML export. 
With the command ` $ npm run livereload`, the writer can write his thesis using his favorite editor, and see the result without having to reload his browser ! :dancer: 

<img width="1396" alt="screen shot 2015-07-26 at 20 02 13" src="https://cloud.githubusercontent.com/assets/1223876/8895204/4380d480-33d1-11e5-982f-cb9d04010b79.png">

