### PR TITLE
make should also work in directories with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ pdf:
 	pandoc "$(INPUTDIR)"/*.md \
 	-o "$(OUTPUTDIR)/thesis.pdf" \
 	-H "$(STYLEDIR)/preamble.tex" \
-	--template "$(STYLEDIR)/template.tex" \
+	--template="$(STYLEDIR)/template.tex" \
 	--bibliography="$(BIBFILE)" 2>pandoc.log \
 	--csl="$(STYLEDIR)/ref_format.csl" \
 	-V fontsize=12pt \

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ help:
 	@echo 'or generic ones from: https://github.com/jgm/pandoc-templates		  '
 
 pdf:
-	pandoc $(INPUTDIR)/*.md \
-	-o $(OUTPUTDIR)/thesis.pdf \
-	-H $(STYLEDIR)/preamble.tex \
-	--template $(STYLEDIR)/template.tex \
-	--bibliography=$(BIBFILE) 2>pandoc.log \
-	--csl=$(STYLEDIR)/ref_format.csl \
+	pandoc "$(INPUTDIR)"/*.md \
+	-o "$(OUTPUTDIR)/thesis.pdf" \
+	-H "$(STYLEDIR)/preamble.tex" \
+	--template "$(STYLEDIR)/template.tex" \
+	--bibliography="$(BIBFILE)" 2>pandoc.log \
+	--csl="$(STYLEDIR)/ref_format.csl" \
 	-V fontsize=12pt \
 	-V papersize=a4paper \
 	-V documentclass:report \
@@ -38,36 +38,36 @@ pdf:
 	--latex-engine=xelatex
 
 tex:
-	pandoc $(INPUTDIR)/*.md \
-	-o $(OUTPUTDIR)/thesis.tex \
-	-H $(STYLEDIR)/preamble.tex \
-	--bibliography=$(BIBFILE) \
+	pandoc "$(INPUTDIR)"/*.md \
+	-o "$(OUTPUTDIR)/thesis.tex" \
+	-H "$(STYLEDIR)/preamble.tex" \
+	--bibliography="$(BIBFILE)" \
 	-V fontsize=12pt \
 	-V papersize=a4paper \
 	-V documentclass:report \
 	-N \
-	--csl=$(STYLEDIR)/ref_format.csl \
+	--csl="$(STYLEDIR)/ref_format.csl" \
 	--latex-engine=xelatex
 
 docx:
-	pandoc $(INPUTDIR)/*.md \
-	-o $(OUTPUTDIR)/thesis.docx \
-	--bibliography=$(BIBFILE) \
-	--csl=$(STYLEDIR)/ref_format.csl \
+	pandoc "$(INPUTDIR)"/*.md \
+	-o "$(OUTPUTDIR)/thesis.docx" \
+	--bibliography="$(BIBFILE)" \
+	--csl="$(STYLEDIR)/ref_format.csl" \
 	--toc
 
 html:
-	pandoc $(INPUTDIR)/*.md \
-	-o $(OUTPUTDIR)/thesis.html \
+	pandoc "$(INPUTDIR)"/*.md \
+	-o "$(OUTPUTDIR)/thesis.html" \
 	--standalone \
-	--template=$(STYLEDIR)/template.html \
-	--bibliography=$(BIBFILE) \
-	--csl=$(STYLEDIR)/ref_format.csl \
-	--include-in-header=$(STYLEDIR)/style.css \
+	--template="$(STYLEDIR)/template.html" \
+	--bibliography="$(BIBFILE)" \
+	--csl="$(STYLEDIR)/ref_format.csl" \
+	--include-in-header="$(STYLEDIR)/style.css" \
 	--toc \
 	--number-sections
-	rm -rf $(OUTPUTDIR)/source
-	mkdir $(OUTPUTDIR)/source
-	cp -r $(INPUTDIR)/figures $(OUTPUTDIR)/source/figures
+	rm -rf "$(OUTPUTDIR)/source"
+	mkdir "$(OUTPUTDIR)/source"
+	cp -r "$(INPUTDIR)/figures" "$(OUTPUTDIR)/source/figures"
 
 .PHONY: help pdf docx html tex


### PR DESCRIPTION
I've figured out `make` does not work in directories with spaces.

Maybe you want to recheck/retest every `make` command in directories with and without spaces with the patch here.