### PR TITLE
Updated README.md with installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,21 @@ There are some minor annoyances:
     - Git, for version control.
 2. [Fork the repository](https://github.com/tompollard/phd_thesis_markdown/fork) on Github  
 3. Clone the repository onto your local computer (or [download the Zip file](https://github.com/tompollard/phd_thesis_markdown/archive/master.zip)).  
-4. Navigate to the directory that contains the Makefile and type "make pdf" (or "make html") at the command line to update the PDF (or HTML) in the output directory.
+4. Navigate to the directory that contains the Makefile and type "make pdf" (or "make html") at the command line to update the PDF (or HTML) in the output directory.  
+**In case of an error** (e.g. `make: *** [pdf] Error 43`) run the following commands:  
+    ```
+    sudo tlmgr install truncate
+    sudo tlmgr install tocloft
+    sudo tlmgr install wallpaper
+    sudo tlmgr install morefloats
+    sudo tlmgr install sectsty
+    sudo tlmgr install siunitx
+    sudo tlmgr install threeparttable
+    sudo tlmgr update l3packages
+    sudo tlmgr update l3kernel
+    sudo tlmgr update l3experimental
+    ```
+    
 5. Edit the files in the 'source' directory, then goto step 4.  
 
 ## What else do I need to know?


### PR DESCRIPTION
On my machine `make pdf` resulted in a lot `make: *** [pdf] Error 43` errors. The causes were missing LaTeX packages.
After installing and updating the packages everything worked smoothly.