### PR TITLE
correct line spacing to 1.5

### DIFF
--- a/style/preamble.tex
+++ b/style/preamble.tex
@@ -65,8 +65,8 @@
 
 % Adjust spacing between lines to 1.5
 \usepackage{setspace}
-% \onehalfspacing
-\doublespacing
+\onehalfspacing
+% \doublespacing
 \raggedbottom
 
 % Set margins


### PR DESCRIPTION
I noticed that `preamble.tex` states:

> "Adjust spacing between lines to 1.5"

but `\onehalfspacing` has been commented out and instead`\doublespacing` is used. Not sure whether this is intentional, in case it isn't, here's a fix.
