### PR TITLE
delete "verbose" option in pdf module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ pdf:
 	-V documentclass:report \
 	-N \
 	--latex-engine=xelatex \
-	--verbose
 
 tex:
 	pandoc "$(INPUTDIR)"/*.md \


### PR DESCRIPTION
option "pandoc --verbose"  is not available in some pandoc versions.
I am using Scientific Linux 7.1 and pandoc 1.12.3.1, "verbose" is not available.