### PR TITLE
Using pandoc-shortcaption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_install:
   # Fetch pandoc and pandoc-citeproc binaries
-  - wget https://github.com/jgm/pandoc/releases/download/1.15.0.5/pandoc-1.15.0.5-1-amd64.deb && ar p pandoc-1.15.0.5-1-amd64.deb data.tar.gz | tar zx
+  - wget https://github.com/jgm/pandoc/releases/download/1.17.2/pandoc-1.17.2-1-amd64.deb && ar p pandoc-1.17.2-1-amd64.deb data.tar.gz | tar zx
   # Install TeX Live
   - sudo add-apt-repository -y ppa:texlive-backports/ppa
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - sudo apt-get install texlive-science
   # Install fonts
   - sudo apt-get install lmodern
+  - sudo pip install pandoc-shortcaption
 
 # Attempt to create a PDF
 script:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help:
 
 pdf:
 	pandoc "$(INPUTDIR)"/*.md \
+	--filter pandoc-shortcaption \
 	-o "$(OUTPUTDIR)/thesis.pdf" \
 	-H "$(STYLEDIR)/preamble.tex" \
 	--template="$(STYLEDIR)/template.tex" \
@@ -47,8 +48,8 @@ tex:
 	-V papersize=a4paper \
 	-V documentclass:report \
 	-N \
-	--csl="$(STYLEDIR)/ref_format.csl" \
-	--latex-engine=xelatex
+	--filter pandoc-shortcaption
+	--csl="$(STYLEDIR)/ref_format.csl"
 
 docx:
 	pandoc "$(INPUTDIR)"/*.md \

--- a/source/06_list_of_figures.md
+++ b/source/06_list_of_figures.md
@@ -1,11 +1,12 @@
+<!--
 # List of figures {.unnumbered}
 
-<!--
 For me, this was the only drawback of writing in Markdown: it is not possible to add a short caption to figures and tables. This means that the \listoftables and \listoffigures commands will generate lists using the full titles, which is probably isn't what you want. For now, the solution is to create the lists manually, when everything else is finished.
 -->
 
-Figure 4.1  This is an example figure . . .              \hfill{pp}  
-Figure x.x  Short title of the figure . . .              \hfill{pp}  
+\listoffigures
+<!--Figure 4.1  This is an example figure . . .              \hfill{pp}  
+Figure x.x  Short title of the figure . . .              \hfill{pp}  -->
 
 \pagenumbering{roman}
 \setcounter{page}{3}

--- a/source/12_chapter_4.md
+++ b/source/12_chapter_4.md
@@ -36,7 +36,7 @@ For details on setting attributes like width and height, see:
 http://pandoc.org/MANUAL.html#extension-link_attributes
 --> 
 
-![RV Calypso is a former British Royal Navy minesweeper converted into a research vessel for the oceanographic researcher Jacques-Yves Cousteau. It was equipped with a mobile laboratory for underwater field research. \label{ref_a_figure}](source/figures/example_figure.pdf){ width=100% }
+![RV Calypso is a former British Royal Navy minesweeper converted into a research vessel for the oceanographic researcher Jacques-Yves Cousteau. It was equipped with a mobile laboratory for underwater field research. \label{ref_a_figure}](source/figures/example_figure.pdf "RV Calypso research vessel"){ width=100% }
 
 ## Conclusion
 


### PR DESCRIPTION
Your work inspired me to create my first pandoc-filter - `pandoc-shortcaption`. It should solve your problem of not being able to use short figure labels, but it probably has a million bugs as well.

You can install this with `pip install pandoc-shortcaption`.