### PR TITLE
fix for appending [H] after figures

### DIFF
--- a/style/template.tex
+++ b/style/template.tex
@@ -7,12 +7,12 @@ $endif$
 
 % Overwrite \begin{figure}[htbp] with \begin{figure}[H]
 \usepackage{float}
-\let\origfigure=\figure
-\let\endorigfigure=\endfigure
-\renewenvironment{figure}[1][]{%
-\origfigure[b]
-}{%
-\endorigfigure
+\let\origfigure\figure
+\let\endorigfigure\endfigure
+\renewenvironment{figure}[1][2] {
+    \expandafter\origfigure\expandafter[H]
+} {
+    \endorigfigure
 }
 
 % fix for pandoc 1.14


### PR DESCRIPTION
The snippet to force figures into positions no longer worked for me.