### PR TITLE
Use secnumdepth variable if set

### DIFF
--- a/style/template.tex
+++ b/style/template.tex
@@ -136,9 +136,9 @@ $endif$
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 $if(numbersections)$
-\setcounter{secnumdepth}{5}
+\setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
 $else$
-\setcounter{secnumdepth}{0}
+\setcounter{secnumdepth}{-2}
 $endif$
 $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes


### PR DESCRIPTION
Currently the section numbering depth is hard-coded to 5. Thus passing the variable `secnumdepth` to pandoc will have no effect.

I suggest to adapt the `secnumdepth` logic from pandoc's integrated [template.tex](https://github.com/jgm/pandoc-templates/blob/master/default.latex).