### PR TITLE
Fixed '! LaTeX Error: Environment cslreferences undefined.'

### DIFF
--- a/style/template.tex
+++ b/style/template.tex
@@ -152,6 +152,15 @@ $if(lang)$
 \fi
 $endif$
 
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+$endif$
+
 $if(title)$
 \title{$title$$if(subtitle)$\\\vspace{0.5em}{\large $subtitle$}$endif$}
 $endif$


### PR DESCRIPTION
Fixed `! LaTeX Error: Environment cslreferences undefined.` error when trying to do `make pdf`. This is due to `pandoc` having later version than when the template was created. Reference [here](https://github.com/mpark/wg21/issues/54)