### PR TITLE
Fix Ubuntu installation with latest pandoc (citeproc), Fix tlmgr use with TinyTex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ os:
   - osx
   - linux  # https://tex.stackexchange.com/questions/313768/why-getting-this-error-tlmgr-unknown-directive
 
-# env:
-  # global:
+env:
+  global:
     # - PATH=$TRAVIS_BUILD_DIR/usr/bin/:$PATH
     # - PATH=/Library/TeX/texbin:$PATH
+    - PATH="$PATH:$HOME/bin"
+    - PATH="$PATH:$HOME/.local/bin"
 
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
@@ -46,9 +48,10 @@ before_install:
       eval "$(/usr/libexec/path_helper)"
       sudo tlmgr update --self
     elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      wget https://github.com/scottkosty/install-tl-ubuntu/raw/master/install-tl-ubuntu && chmod +x ./install-tl-ubuntu
-      sudo ./install-tl-ubuntu
+      wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
       sudo env PATH=$PATH tlmgr update --self
+      TEMP_DEB="$(mktemp)" && wget -O "$TEMP_DEB" 'https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-1-amd64.deb' && sudo dpkg -i "$TEMP_DEB"
+      rm -f "$TEMP_DEB"
       echo MSG FROM JO:
       echo on linux we cannot update apt installed texlive
       echo next steps to fix see commit msg: https://github.com/tompollard/phd_thesis_markdown/pull/100/commits/85fd9e7ac413a34066b79f1e49b3e1d3efdeac00

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: bash
 
 os:
   - osx
-  # - linux  # https://tex.stackexchange.com/questions/313768/why-getting-this-error-tlmgr-unknown-directive
+  - linux  # https://tex.stackexchange.com/questions/313768/why-getting-this-error-tlmgr-unknown-directive
 
 # env:
   # global:
@@ -29,8 +29,9 @@ python:
 addons:
   apt:
     packages:
-    - texlive
+    # - texlive
     - xzdec
+    - python3-pip
     update: true
   homebrew:
     casks:
@@ -45,7 +46,9 @@ before_install:
       eval "$(/usr/libexec/path_helper)"
       sudo tlmgr update --self
     elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      tlmgr init-usertree
+      wget https://github.com/scottkosty/install-tl-ubuntu/raw/master/install-tl-ubuntu && chmod +x ./install-tl-ubuntu
+      sudo ./install-tl-ubuntu
+      sudo env PATH=$PATH tlmgr update --self
       echo MSG FROM JO:
       echo on linux we cannot update apt installed texlive
       echo next steps to fix see commit msg: https://github.com/tompollard/phd_thesis_markdown/pull/100/commits/85fd9e7ac413a34066b79f1e49b3e1d3efdeac00

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,17 +101,17 @@ install:
   # Installs both python and texlive dependencies
   - make install
   # For debug
-  - cat /usr/local/texlive/2020/texmf-var/web2c/tlmgr.log
-  - conda list
-  - pip list
-  - python --version
-  - pandoc --version
-  - tlmgr --version
-  - latex --version
-  - echo $PATH
-  - which tlmgr
-  - which latex
-  - find /usr/local/texlive/2020/ -type f -name "l3backend*"
+  # - cat /usr/local/texlive/2020/texmf-var/web2c/tlmgr.log
+  # - conda list
+  # - pip list
+  # - python --version
+  # - pandoc --version
+  # - tlmgr --version
+  # - latex --version
+  # - echo $PATH
+  # - which tlmgr
+  # - which latex
+  # - find /usr/local/texlive/2020/ -type f -name "l3backend*"
 
 # Attempt to create all document output types
 script:
@@ -122,10 +122,10 @@ script:
   - make pdf
   - cat pandoc.pdf.log
   # Debugging the mac error
-  - find /usr/local/texlive/2020/ -type f -name "l3backend*"
+  # - find /usr/local/texlive/2020/ -type f -name "l3backend*"
   - make html
   - cat pandoc.html.log
   - make docx
-  - cat pandoc.docx.log
+  # - cat pandoc.docx.log
   - make all
-  - cat pandoc.*.log
+  # - cat pandoc.*.log

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ conda create -n phd -y python=3.7 pandoc
 conda activate phd
 
 # Install required python and texlive packages
+sudo apt install python3-pip # for Ubuntu
 make install
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ If you have used this template in your work, please cite the following publicati
 > Tom Pollard et al. (2016). Template for writing a PhD thesis in Markdown. Zenodo. http://dx.doi.org/10.5281/zenodo.58490
 
 ## Quickstart
+### Mac
 If you're a mac user and you have conda and brew installed, run the following in your terminal to install and generate the example outputs:
 ```bash
 # get texlive
@@ -24,10 +25,25 @@ conda create -n phd -y python=3.7 pandoc
 conda activate phd
 
 # Install required python and texlive packages
-sudo apt install python3-pip # for Ubuntu
 make install
 ```
 
+### Ubuntu
+On Ubuntu, texlive installed with apt is not working, use an installer like below and make sure it is not installed with apt:
+```bash
+# get texlive
+wget https://github.com/scottkosty/install-tl-ubuntu/raw/master/install-tl-ubuntu && chmod +x ./install-tl-ubuntu
+sudo ./install-tl-ubuntu
+
+# update tlmgr and packages
+sudo env PATH=$PATH tlmgr update --self
+
+# Install pip
+sudo apt install python3-pip
+
+# Install required python and texlive packages
+make install
+```
 ## Why write my thesis in Markdown?
 
 Markdown is a super-friendly plain text format that can be easily converted to a bunch of other formats like PDF, Word and LaTeX. You'll enjoy working in Markdown because:

--- a/README.md
+++ b/README.md
@@ -31,15 +31,22 @@ make install
 ### Ubuntu
 On Ubuntu, texlive installed with apt is not working, use an installer like below and make sure it is not installed with apt:
 ```bash
-# get texlive
-wget https://github.com/scottkosty/install-tl-ubuntu/raw/master/install-tl-ubuntu && chmod +x ./install-tl-ubuntu
-sudo ./install-tl-ubuntu
+# get TinyTex and make sure PATH is set
+wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
+PATH="$PATH:$HOME/bin"
+PATH="$PATH:$HOME/.local/bin"
 
 # update tlmgr and packages
 sudo env PATH=$PATH tlmgr update --self
 
 # Install pip
 sudo apt install python3-pip
+
+# Install latest pandoc (apt version too old, needs at least 2.11.*)
+TEMP_DEB="$(mktemp)" &&
+wget -O "$TEMP_DEB" 'https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-1-amd64.deb' &&
+sudo dpkg -i "$TEMP_DEB"
+rm -f "$TEMP_DEB"
 
 # Install required python and texlive packages
 make install

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,30 +1,32 @@
 #!/usr/bin/env bash
 
 set -e  # makes the script fail as soon as one command fails
-# removed sudo as an alias was used in bash.rc and in session: alias sudo='sudo env PATH=$PATH'
+# alias needed for tlmgr installation on Ubuntu with https://github.com/scottkosty/install-tl-ubuntu
+# alias tlmgr='/opt/texbin/tlmgr'
+# alias sudo='sudo env PATH=$PATH' this must be set to carry out sudo on tlmgr
+# this script must be run with make install and alias tlmgr set before like above
 
-tlmgr install truncate
-tlmgr install tocloft
-tlmgr install wallpaper
-tlmgr install morefloats
-tlmgr install sectsty
-tlmgr install siunitx
-tlmgr install threeparttable
-tlmgr update l3packages
-tlmgr update l3kernel
-tlmgr update l3experimental
-tlmgr update l3backend
-# to be installed too:
-# mathspec
-# xltxtra
-# realscripts
-# eso-pic
-# ctable
-# listings
-# pdfpages
-# bbold
-# cleveref
-# 
+sudo env PATH=$PATH tlmgr install truncate
+sudo env PATH=$PATH tlmgr install tocloft
+sudo env PATH=$PATH tlmgr install wallpaper
+sudo env PATH=$PATH tlmgr install morefloats
+sudo env PATH=$PATH tlmgr install sectsty
+sudo env PATH=$PATH tlmgr install siunitx
+sudo env PATH=$PATH tlmgr install threeparttable
+sudo env PATH=$PATH tlmgr update l3packages
+sudo env PATH=$PATH tlmgr update l3kernel
+sudo env PATH=$PATH tlmgr update l3experimental
+sudo env PATH=$PATH tlmgr update l3backend
+sudo env PATH=$PATH tlmgr install mathspec
+sudo env PATH=$PATH tlmgr install xltxtra
+sudo env PATH=$PATH tlmgr install realscripts
+sudo env PATH=$PATH tlmgr install eso-pic
+sudo env PATH=$PATH tlmgr install ctable
+sudo env PATH=$PATH tlmgr install listings
+sudo env PATH=$PATH tlmgr install pdfpages
+sudo env PATH=$PATH tlmgr install bbold
+sudo env PATH=$PATH tlmgr install cleveref
+#
 # Would it be simpler to just update all packages? (takes ~10m)
 # sudo tlmgr update --all
 pip install pandoc-fignos pandoc-eqnos pandoc-tablenos pandoc-secnos pandoc-shortcaption

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
 set -e  # makes the script fail as soon as one command fails
-# texlive installation necessary with: https://github.com/scottkosty/install-tl-ubuntu
-# alias tlmgr='/opt/texbin/tlmgr' to be set in .bashrc file or appropriate
-# sudo env PATH=$PATH' is needed to carry out sudo on tlmgr, which is not installed with apt,
-# see https://github.com/scottkosty/install-tl-ubuntu/issues/13
 
 sudo env PATH=$PATH tlmgr install truncate
 sudo env PATH=$PATH tlmgr install tocloft

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -26,6 +26,11 @@ sudo env PATH=$PATH tlmgr install listings
 sudo env PATH=$PATH tlmgr install pdfpages
 sudo env PATH=$PATH tlmgr install bbold
 sudo env PATH=$PATH tlmgr install cleveref
+sudo env PATH=$PATH tlmgr install fancyhdr
+sudo env PATH=$PATH tlmgr install ulem
+sudo env PATH=$PATH tlmgr install setspace
+sudo env PATH=$PATH tlmgr install makecell
+sudo env PATH=$PATH tlmgr install pdflscape
 #
 # Would it be simpler to just update all packages? (takes ~10m)
 # sudo tlmgr update --all

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,18 +1,30 @@
 #!/usr/bin/env bash
 
 set -e  # makes the script fail as soon as one command fails
+# removed sudo as an alias was used in bash.rc and in session: alias sudo='sudo env PATH=$PATH'
 
-sudo tlmgr install truncate
-sudo tlmgr install tocloft
-sudo tlmgr install wallpaper
-sudo tlmgr install morefloats
-sudo tlmgr install sectsty
-sudo tlmgr install siunitx
-sudo tlmgr install threeparttable
-sudo tlmgr update l3packages
-sudo tlmgr update l3kernel
-sudo tlmgr update l3experimental
-sudo tlmgr update l3backend
+tlmgr install truncate
+tlmgr install tocloft
+tlmgr install wallpaper
+tlmgr install morefloats
+tlmgr install sectsty
+tlmgr install siunitx
+tlmgr install threeparttable
+tlmgr update l3packages
+tlmgr update l3kernel
+tlmgr update l3experimental
+tlmgr update l3backend
+# to be installed too:
+# mathspec
+# xltxtra
+# realscripts
+# eso-pic
+# ctable
+# listings
+# pdfpages
+# bbold
+# cleveref
+# 
 # Would it be simpler to just update all packages? (takes ~10m)
 # sudo tlmgr update --all
 pip install pandoc-fignos pandoc-eqnos pandoc-tablenos pandoc-secnos pandoc-shortcaption

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 set -e  # makes the script fail as soon as one command fails
-# alias needed for tlmgr installation on Ubuntu with https://github.com/scottkosty/install-tl-ubuntu
-# alias tlmgr='/opt/texbin/tlmgr'
-# alias sudo='sudo env PATH=$PATH' this must be set to carry out sudo on tlmgr
-# this script must be run with make install and alias tlmgr set before like above
+# texlive installation necessary with: https://github.com/scottkosty/install-tl-ubuntu
+# alias tlmgr='/opt/texbin/tlmgr' to be set in .bashrc file or appropriate
+# sudo env PATH=$PATH' is needed to carry out sudo on tlmgr, which is not installed with apt,
+# see https://github.com/scottkosty/install-tl-ubuntu/issues/13
 
 sudo env PATH=$PATH tlmgr install truncate
 sudo env PATH=$PATH tlmgr install tocloft

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -31,6 +31,8 @@ sudo env PATH=$PATH tlmgr install ulem
 sudo env PATH=$PATH tlmgr install setspace
 sudo env PATH=$PATH tlmgr install makecell
 sudo env PATH=$PATH tlmgr install pdflscape
+sudo env PATH=$PATH tlmgr install caption
+
 #
 # Would it be simpler to just update all packages? (takes ~10m)
 # sudo tlmgr update --all


### PR DESCRIPTION
# Issue
As pandoc-citeproc is depreciated (#100), the installation on linux needs the latest pandoc-version to use the successor citeproc.
In addition, a standard installation of TexLive using apt and currently also via an [installer](https://tex.stackexchange.com/questions/1092/how-to-install-vanilla-texlive-on-debian-or-ubuntu) is causing problems with [tlmgr](https://tex.stackexchange.com/questions/295286/tlmgr-how-to-disable-switch-to-user-mode) and some LaTex packages are missing, depending on the distribution (probably related to #84 ).

# Fix
- install latest pandoc version via travis
- install TinyTex
- update install script for linux to add needed LaTex packages (using tlmgr)
- adjust PATH for tlmgr
- add Readme Quickstart for Ubuntu with those instructions (applicable for Linux in general?)

# Comments
As of now, if new packages are needed in future changes, they have to be installed manually (or added in the install script), as there is no "needed packages detection" that I am aware of.

Even if TinyTex comes with advantages over full TexLive with less space (~300 MB vs. ~6500 MB) and faster installation, a full TexLive installation could be desired (or is already present on a system which eventually can cause interference with TinyTex). A way how to setup that and avoid installation problems with the full TexLive as mentioned above would be a next step, as mentioned in #100 too.

At the current state, the installation should work well with TinyTex on Ubuntu.