### PR TITLE
Fix page numbering

### DIFF
--- a/source/05_table_of_contents.md
+++ b/source/05_table_of_contents.md
@@ -1,4 +1,4 @@
-\pagenumbering{gobble}
+\pagenumbering{arabic}
 
 \tableofcontents
 


### PR DESCRIPTION
Hi there! 
After going slightly insane for around an hour, I realized that `gobble` was the cause for my missing page numbers. #71 is mentioning this, but I didn't expect this to be an issue anymore after 3 years and the location of that line wasn't mentioned. Because the compiled `thesis.pdf` in this repo actually contains page numbers even though it shouldn't, I checked pretty much everything else before checking the toc file. Hope this little change can save some other people a little bit of time :)