### PR TITLE
Migrate to `pandoc-crossref` and add short captions filters for figures and tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ pdf:
 		--pdf-engine=xelatex \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-crossref \
 		--lua-filter=filters/figure-short-captions.lua \
 		--lua-filter=filters/table-short-captions.lua \
+		--filter=pandoc-crossref \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \
@@ -72,9 +72,9 @@ tex:
 		--pdf-engine=xelatex \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-crossref \
 		--lua-filter=filters/figure-short-captions.lua \
 		--lua-filter=filters/table-short-captions.lua \
+		--filter=pandoc-crossref \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \
@@ -90,9 +90,9 @@ html:
 		--toc \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-crossref \
 		--lua-filter=filters/figure-short-captions.lua \
 		--lua-filter=filters/table-short-captions.lua \
+		--filter=pandoc-crossref \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \
@@ -109,9 +109,9 @@ docx:
 		--toc \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-crossref \
 		--lua-filter=filters/figure-short-captions.lua \
 		--lua-filter=filters/table-short-captions.lua \
+		--filter=pandoc-crossref \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,9 @@ pdf:
 		--pdf-engine=xelatex \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-shortcaption \
-		--filter=pandoc-xnos \
+		--filter=pandoc-crossref \
+		--lua-filter=filters/figure-short-captions.lua \
+		--lua-filter=filters/table-short-captions.lua \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \
@@ -71,8 +72,9 @@ tex:
 		--pdf-engine=xelatex \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-shortcaption \
-		--filter=pandoc-xnos \
+		--filter=pandoc-crossref \
+		--lua-filter=filters/figure-short-captions.lua \
+		--lua-filter=filters/table-short-captions.lua \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \
@@ -88,8 +90,9 @@ html:
 		--toc \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-shortcaption \
-		--filter=pandoc-xnos \
+		--filter=pandoc-crossref \
+		--lua-filter=filters/figure-short-captions.lua \
+		--lua-filter=filters/table-short-captions.lua \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \
@@ -106,8 +109,9 @@ docx:
 		--toc \
 		"$(INPUTDIR)"/*.md \
 		"$(INPUTDIR)/metadata.yml" \
-		--filter=pandoc-shortcaption \
-		--filter=pandoc-xnos \
+		--filter=pandoc-crossref \
+		--lua-filter=filters/figure-short-captions.lua \
+		--lua-filter=filters/table-short-captions.lua \
 		--bibliography="$(BIBFILE)" \
 		--citeproc \
 		--csl="$(STYLEDIR)/ref_format.csl" \

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There are several ways to install TeXLive. [This guide](https://help.ubuntu.com/
 
 ## Should I use this template?
 
-## Why write my thesis in Markdown?
+### Why write my thesis in Markdown?
 
 Markdown is a super-friendly plain text format that can be easily converted to a bunch of other formats like PDF, Word and LaTeX. You'll enjoy working in Markdown because:
 - it is a clean, plain-text format...
@@ -59,7 +59,7 @@ Markdown is a super-friendly plain text format that can be easily converted to a
 - it is able to take advantage of autocompletion capabilities for figures and citations in several text editors (VSCode, Sublime, etc.)
 - there is no lock-in. If you decide that Markdown isn't for you, then just output to Word, or whatever, and continue working in the new format.
 
-## Are there any reasons not to use Markdown?
+### Are there any reasons not to use Markdown?
 
 There are some minor annoyances:
 - if you haven't worked with Markdown before then you'll find yourself referring to the style-guide (`pandoc` User Guide) fairly often at first.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ There are some minor annoyances:
 - the style documents in this framework could be improved. The PDF and HTML (thanks [@ArcoMul](https://github.com/ArcoMul)) outputs are acceptable, but ~~HTML and~~ Word needs work if you plan to output to this format.  
 - ... if there are more, please add them here.
 
-## Template instructions
+## Detailed template information
 
 ### How is the template organised?
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ If you have used this template in your work, please cite the following publicati
 
 > Tom Pollard et al. (2016). Template for writing a PhD thesis in Markdown. Zenodo. http://dx.doi.org/10.5281/zenodo.58490
 
-## Quickstart
-If you're a mac user and you have conda and brew installed, run the following in your terminal to install and generate the example outputs:
+## Installation
+
+1. Install [`pandoc`](https://pandoc.org/releases.html). **This repository requires `pandoc` 3.1+**, so if you install `pandoc` using a package manager (e.g. `apt`), check that it meets the version requirement. Otherwise, install by following the link.
+2. Install [`pandoc-crossref`](https://github.com/lierdakil/pandoc-crossref#installation), a `pandoc` filter for numbering and cross-referencing figures, tables, sections and code blocks.
+3. Install the required TeX packages to enable compilation to PDF.
+
+### Quickstart for Mac Users
+If you're a Mac user and you have `conda` and `brew` installed, run the following in your terminal to install `pandoc` and TeX packages (steps 1 & 3):
 ```bash
 # get texlive
 brew install --cask mactex
@@ -26,6 +32,20 @@ conda activate phd
 # Install required python and texlive packages
 make install
 ```
+### Notes for Linux Users
+There are several ways to install TeXLive. [This guide](https://help.ubuntu.com/community/LaTeX) (written for Ubuntu) may be useful. In short, you can:
+
+1. Install TeXLive from repositories (for Ubuntu, autocomplete `apt install texlive` to see all available packages), or;
+2. Install TeXLive manually and use the package manager (`tlmgr`) to install required packages. If you go down this route, you can run `make install` to install required TeXLive packages.
+
+## Handy references
+
+- [`pandoc` User Guide](https://pandoc.org/MANUAL.html) for Markdown syntax for figures, tables, lists, etc., as well as information on flags that can be used when calling `pandoc`
+- [`pandoc-crossref` manual](https://lierdakil.github.io/pandoc-crossref/) which outlines syntax and customisation options for cross-referencing (e.g. should the figure prefix be "fig,", "Fig." or "Figure")
+- [This `README`](https://github.com/pandoc/lua-filters/blob/master/short-captions/README.md) for `pandoc-crossref`-compatible syntax to have shorter captions for figures in the List of Figures (PDF/LaTeX output only)
+- [This `README`](https://github.com/pandoc/lua-filters/blob/master/table-short-captions/README.md) for `pandoc-crossref`-compatible syntax to have shorter captions for tables in the List of Tables (PDF/LaTeX output only)
+
+## Should I use this template?
 
 ## Why write my thesis in Markdown?
 
@@ -33,7 +53,7 @@ Markdown is a super-friendly plain text format that can be easily converted to a
 - it is a clean, plain-text format...
 - ...but you can use LaTeX when you need it (for example, in laying out mathematical formula).
 - it doesn't suffer from the freezes and crashes that some of us experience when working with large, image-heavy Word documents.
-- it automatically handles the table of contents, bibliography etc with Pandoc.
+- it automatically handles the table of contents, bibliography etc with `pandoc`.
 - comments, drafts of text, etc can be added to the document by wrapping them in &lt;!--  --&gt;
 - it works well with Git, so keeping backups is straightforward. Just commit the changes and then push them to your repository.
 - it is able to take advantage of autocompletion capabilities for figures and citations in several text editors (VSCode, Sublime, etc.)
@@ -42,42 +62,40 @@ Markdown is a super-friendly plain text format that can be easily converted to a
 ## Are there any reasons not to use Markdown?
 
 There are some minor annoyances:
-- if you haven't worked with Markdown before then you'll find yourself referring to the style-guide fairly often at first.
-- it isn't possible to add a short caption to tables ~~and figures~~ ([figures are now fixed](https://github.com/tompollard/phd_thesis_markdown/pull/47), thanks to @martisak). This means that /listoftables includes the long-caption, which probably isn't what you want. If you want to include the list of tables, then you'll need to write it manually.
+- if you haven't worked with Markdown before then you'll find yourself referring to the style-guide (`pandoc` User Guide) fairly often at first.
+- Some niche and more complicated requirements will require writing raw LaTeX, which won't appear in other output formats. In the worst case, it will require diving into Haskell or Lua filters for `pandoc`
 - the style documents in this framework could be improved. The PDF and HTML (thanks [@ArcoMul](https://github.com/ArcoMul)) outputs are acceptable, but ~~HTML and~~ Word needs work if you plan to output to this format.  
-- ~~there is no straightforward way of specifying image size in the markdown right now, though this functionality is coming (see: https://github.com/tompollard/phd_thesis_markdown/issues/15)~~ (Image size can now be specified. Thanks to @rudolfbyker for [highlighting this](https://github.com/tompollard/phd_thesis_markdown/issues/15)).
 - ... if there are more, please add them here.
 
-## How is the template organised?
+## Template instructions
+
+### How is the template organised?
 
 - README.md => these instructions.
 - License.md => terms of reuse (MIT license).
-- Makefile => contains instructions for using Pandoc to produce the final thesis.
+- Makefile => contains instructions for using `pandoc` to produce the final thesis.
 - output/ => directory to hold the final version.
 - source/ => directory to hold the thesis content. Includes the references.bib file.
 - scratch/ => directory to hold tables which can be converted between different formats.
 - source/figures/ => directory to hold the figures.
 - style/ => directory to hold the style documents.
 
-## How do I get started?
+### How do I get started?
 
-1. Install the following software:
+1. Install the software outlined above, as well as:
     - A text editor, like [Sublime](https://www.sublimetext.com/), which is what you'll use write the thesis.  
-    - A LaTeX distribution (for example, [MacTeX](https://tug.org/mactex/) for Mac users).
-    - [Pandoc](http://johnmacfarlane.net/pandoc), for converting the Markdown to the output format of your choice.  
-    - Pandoc plugins by running ```make install```
     - Git, for version control.
 2. [Fork the repository](https://github.com/tompollard/phd_thesis_markdown/fork) on Github  
 3. Clone the repository onto your local computer (or [download the Zip file](https://github.com/tompollard/phd_thesis_markdown/archive/master.zip)).
-4. (Skip this step to use default UCL style) Configure style for your institution - see instructions below
+4. (Skip this step to use default UCL style) Configure style for your institution. See instructions below
 5. Navigate to the directory that contains the Makefile and type "make pdf" (or "make html") at the command line to update the PDF (or HTML) in the output directory.  
 **In case of an error** (e.g. `make: *** [pdf] Error 43`), consult [this article](https://dalwilliams.com/lessons-learned-from-writing-a-phd-dissertation-in-markdown.html) for possible fixes. Most importantly, make sure tlmgr is properly installed, then run ```install.sh``
 6. Edit the files in the 'source' directory, then goto step 5.
 
-## How does it work?
+### How does it work?
 The universal document converter [`pandoc`](https://pandoc.org/) does all the heavy lifting. For example:
 
-1. `make pdf` (the code under `pdf: ...` in [`Makefile`](./Makefile)) runs `pandoc` which takes as input
+-  `make pdf` (the code under `pdf: ...` in [`Makefile`](./Makefile)) runs `pandoc` which takes as input
     1. the markdown files which contain the writing content: `input/*.md`
     1. a yaml file with metadata: `input/metadata.yml`
     1. a LaTeX template: `style/template.tex`
@@ -87,12 +105,12 @@ The universal document converter [`pandoc`](https://pandoc.org/) does all the he
     1. a bunch of options which change the output e.g. `--number-sections`
 1. the output produced is:
     1. the generated pdf: [`output/thesis.pdf`](./output/thesis.pdf)
-    1. logs (which contain the `.tex` which was compiled): `pandoc.pdf.log`    
+    1. logs (which contain the `.tex` which was compiled): `pandoc.pdf.log`
 
 Put simply, `pandoc` uses the latex template provided to create a `.tex` file, then compiles it. In detail, `pandoc` processes the input files in the following way (the file names in quotes aren't visible to you, but are named for the purpose of understanding):
 1. Make replacements within the markdown files `input/*.md` e.g.:
     * references to figures, captions, and sections are handled: `@fig:my_fig` -> `\ref{fig:my_fig}`
-    * equations are converted to LaTeX and numbered: `$f(x) = ax^3 + bx^2 + cx + d$ {#eq:my_equation}` -> `\begin{equation}f(x) = ax^3 + bx^2 + cx + d\label{eq:my_equation}\end{equation}`
+    * equations are converted to LaTeX and numbered: `$$f(x) = ax^3 + bx^2 + cx + d$$ {#eq:my_equation}` -> `\begin{equation}f(x) = ax^3 + bx^2 + cx + d\label{eq:my_equation}\end{equation}`
     * citations are handled: `[@Cousteau1963]` -> `(Cousteau Jacques & Dugan James 1963)`
     * see `input/*.md` for more examples!
 1. Create "`body.tex`" by:
@@ -105,14 +123,13 @@ Put simply, `pandoc` uses the latex template provided to create a `.tex` file, t
 1. Compile `thesis.tex` (you can see the logs for this process, and what "`thesis.tex`" would look like in `pandoc.pdf.log`)
     * **TIP**: You can also generate and view `output/thesis.tex` by running `make tex` - this follows all the above steps, bar the final compilation
 
-## What else do I need to know?
+### What else do I need to know?
 
 Some useful points, in a random order:
-- if you only care about generating `theis.pdf` you can always fall back on writing LaTeX within the markdown files (but note that `theis.html` and other outputs will not be able to render this)
+- if you only care about generating `thesis.pdf` you can always fall back on writing LaTeX within the markdown files (but note that `thesis.html` and other outputs will not be able to render this)
 - the markdown files you write (i.e. your chapters) will be compiled in alphabetical order, so keep the filenames sorted in the order you want them to appear e.g. `01_chapter_1.md`, `02_chapter_2.md`, etc. This is required because of the way we have written `make pdf`. You can change this behaviour by writing a custom `pandoc` command instead of using `make pdf`.
 - each chapter must finish with at least one blank line, otherwise the header of the following chapter may not be picked up.
 - add two spaces at the end of a line to force a line break.
-- the template uses [John Macfarlane's Pandoc](http://johnmacfarlane.net/pandoc/README.html) to generate the output documents. Refer to this page for Markdown formatting guidelines.
 - PDFs are generated using the LaTeX templates in the style directory. Fonts etc can be changed in the TeX templates.
 - To change the citation style, just overwrite ref_format.csl with the new style. Style files can be obtained from [citationstyles.org/](http://citationstyles.org/)
 - For fellow web developers, there is a Grunt task file (Gruntfile.js) which can be used to 'watch' the markdown files. By running `$ npm install` and then `$ npm run watch` the PDF and HTML export is done automatically when saving a Markdown file.
@@ -137,7 +154,6 @@ sudo tlmgr l3backend
 # Contributing
 
 Contributions to the template are encouraged! There are lots of things that could be improved, like:
-- finding a way to add short captions for the tables, so that the lists of tables can be automatically generated.
 - cleaning up the LaTeX templates, which are messy at the moment.
 - improving the style of Word and TeX outputs.
 

--- a/filters/figure-short-captions.lua
+++ b/filters/figure-short-captions.lua
@@ -1,0 +1,12 @@
+-- Credit to jpcirrus for code: https://github.com/jgm/pandoc/issues/7915#issuecomment-1427113349
+PANDOC_VERSION:must_be_at_least '3.1'
+
+if FORMAT:match "latex" then
+  function Figure(f)
+    local short = f.content[1].content[1].attributes['short-caption']
+    if short and not f.caption.short then
+      f.caption.short = pandoc.Inlines(short)
+    end
+    return f
+  end
+end

--- a/filters/table-short-captions.lua
+++ b/filters/table-short-captions.lua
@@ -1,0 +1,229 @@
+---LaTeXTableShortCapts – enable `.unlisted` and `short-caption=""` properties
+--                        for Pandoc conversion to LaTeX
+
+--[[
+Copyright (c) 2019 Blake Riley
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+]]
+local List = require 'pandoc.List'
+
+-- don't do anything unless we target latex
+if FORMAT ~= "latex" then
+  return {}
+end
+
+--- Code for injection into the LaTeX header,
+--  to overwrite a macro in longtable captions.
+longtable_caption_mod = [[
+% -- begin:latex-table-short-captions --
+\makeatletter\AtBeginDocument{%
+\def\LT@c@ption#1[#2]#3{%                 % Overwrite the workhorse macro used in formatting a longtable caption.
+  \LT@makecaption#1\fnum@table{#3}%
+  \@ifundefined{pandoctableshortcapt}
+     {\def\@tempa{#2}}                    % Use default behaviour: argument in square brackets
+     {\let\@tempa\pandoctableshortcapt}   % If defined (even if blank), use to override
+  \ifx\@tempa\@empty\else                 % If @tempa is blank, no lot entry! Otherwise, @tempa becomes the lot title.
+     {\let\\\space
+     \addcontentsline{lot}{table}{\protect\numberline{\thetable}{\@tempa}}}%
+  \fi}
+}\makeatother
+% -- end:latex-table-short-captions --
+]]
+
+--- Creates a def shortcaption block to be placed before the table
+-- @tparam ?string sc : The short-caption property value
+-- @treturn Plain : The def shortcaption block
+local function defshortcapt(sc)
+  local scblock = List:new{}
+  scblock:extend {pandoc.RawInline('tex', "\\def\\pandoctableshortcapt{")}
+  if sc then
+    scblock:extend (pandoc.read(sc).blocks[1].c)
+  end
+  scblock:extend {pandoc.RawInline('tex', "}")}
+  if not sc then
+    scblock:extend {pandoc.RawInline('tex', "  % .unlisted")}
+  end
+  return pandoc.Plain(scblock)
+end
+
+--- The undef shortcaption block to be placed after the table
+local undefshortcapt = pandoc.RawBlock('tex', "\\let\\pandoctableshortcapt\\relax")
+
+--- Parses a mock "Table Attr".
+-- We use the Attr of an empty Span as if it were Table Attr.
+-- This function extracts what is needed to build a short-caption.
+-- @tparam Attr attr : The Attr of the property Span in the table caption
+-- @treturn ?string : The identifier
+-- @treturn ?string : The "short-caption" property, if present.
+-- @treturn bool : Whether ".unlisted" appeared in the classes
+local function parse_table_attrs(attr)
+  -- Find label
+  local label = nil
+  if attr.identifier and (#attr.identifier > 0) then
+    label = attr.identifier
+  end
+
+  -- Look for ".unlisted" in classes
+  local unlisted = false
+  if attr.classes:includes("unlisted") then
+    unlisted = true
+  end
+
+  -- If not unlisted, then find the property short-caption.
+  local short_caption = nil
+  if not unlisted then
+    if (attr.attributes["short-caption"]) and
+       (#attr.attributes["short-caption"] > 0) then
+      short_caption = attr.attributes['short-caption']
+    end
+  end
+
+  return label, short_caption, unlisted
+end
+
+function is_properties_span(inl)
+  return (inl.t) and (inl.t == "Span")                      -- is span
+                 and (inl.content) and (#inl.content == 0)  -- is empty span
+end
+
+--- Parse the caption for Pandoc < 2.10
+-- @tparam Table tbl : The table with {}-wrapped properties in the caption
+-- @treturn ?string : The "short-caption" property, if present.
+-- @treturn bool : Whether ".unlisted" appeared in the classes
+function parse_short_caption_legacy(tbl)
+  local caption = tbl.caption
+
+  -- Escape if there is no caption present.
+  if not caption or #caption == 0 then
+    return nil
+  end
+
+  -- Try find the properties block
+  local propspan, idx = caption:find_if(is_properties_span)
+
+  -- If we couldn't find properties, escape.
+  if not propspan then
+    return nil
+  end
+
+  -- Otherwise, parse it all
+  local label, short_caption, unlisted = parse_table_attrs(propspan.attr)
+
+  -- Excise the span from the caption
+  caption[idx] = nil
+
+  -- Put label back into caption for pandoc-crossref
+  if label then
+    caption:extend {pandoc.Str("{#"..label.."}")}
+  end
+
+  -- set new caption
+  tbl.caption = caption
+
+  return short_caption, unlisted
+end
+
+--- Parse the caption for Pandoc >= 2.10
+-- @tparam Table tbl : The table with {}-wrapped properties in the caption
+-- @treturn ?string : The "short-caption" property, if present.
+-- @treturn bool : Whether ".unlisted" appeared in the classes
+function parse_short_caption(tbl)
+  local caption = pandoc.List(tbl.caption.long)
+
+  -- Escape if there is no caption present.
+  if #caption == 0 then
+    return nil
+  end
+
+  -- Try find the properties block
+  local find_properties = function (list)
+    for bidx, block in ipairs(list) do
+      local propspan, idx = block.content:find_if(is_properties_span)
+      if propspan then
+        return propspan, bidx, idx
+      end
+    end
+  end
+  local propspan, bidx, idx = find_properties(caption)
+
+  -- If we couldn't find properties, escape.
+  if not propspan then
+    return nil
+  end
+
+  -- Otherwise, parse it all
+  local label, short_caption, unlisted = parse_table_attrs(propspan.attr)
+
+  -- Excise the span from the caption
+  caption[bidx].content[idx] = nil
+
+  -- Put label back into caption for pandoc-crossref
+  if label then
+    caption[bidx].content:extend {pandoc.Str("{#"..label.."}")}
+  end
+
+  -- set new caption
+  tbl.caption.long = caption
+  tbl.caption.short = short_caption
+    and pandoc.read(short_caption, FORMAT).blocks[1].content
+    or nil
+
+  return short_caption, unlisted
+end
+
+--- Wraps a table with shortcaption code
+-- @tparam Table tbl : The table with {}-wrapped properties in the caption
+-- @treturn List[Blocks] : The table with {label} in the caption,
+--                         optionally wrapped in shortcaption code
+function rewrite_longtable_caption(tbl)
+  local short_caption, unlisted
+  if PANDOC_VERSION >= {2,10} then
+    short_caption, unlisted = parse_short_caption(tbl)
+  else
+    short_caption, unlisted = parse_short_caption_legacy(tbl)
+  end
+
+  -- Place new table
+  local result = List:new{}
+  if short_caption or unlisted then
+    result:extend {defshortcapt(short_caption)}
+  end
+  result:extend {tbl}
+  if short_caption or unlisted then
+    result:extend {undefshortcapt}
+  end
+  return result
+end
+
+--- Inserts longtable_caption_mod into the header_includes
+-- @tparam Meta meta : The document metadata
+-- @treturn Meta : The document metadata, with replacement LaTeX macro
+--                 in header_includes
+function add_longtable_caption_mod(meta)
+  local header_includes = -- test ? a : b
+    (meta['header-includes'] and meta['header-includes'].t == 'MetaList')
+    and meta['header-includes']
+    or pandoc.MetaList{meta['header-includes']}
+  header_includes[#header_includes + 1] =
+    pandoc.MetaBlocks{pandoc.RawBlock('tex', longtable_caption_mod)}
+  meta['header-includes'] = header_includes
+  return meta
+end
+
+return {
+  {
+    Meta = add_longtable_caption_mod,
+    Table = rewrite_longtable_caption,
+  }
+}

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -15,4 +15,3 @@ sudo tlmgr update l3experimental
 sudo tlmgr update l3backend
 # Would it be simpler to just update all packages? (takes ~10m)
 # sudo tlmgr update --all
-pip install pandoc-fignos pandoc-eqnos pandoc-tablenos pandoc-secnos pandoc-shortcaption

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -15,4 +15,3 @@ sudo tlmgr update l3experimental
 sudo tlmgr update l3backend
 # Would it be simpler to just update all packages? (takes ~10m)
 # sudo tlmgr update --all
-pip install pandoc-fignos pandoc-eqnos pandoc-tablenos pandoc-secnos pandoc-shortcaption

--- a/output/thesis.html
+++ b/output/thesis.html
@@ -12,6 +12,7 @@
             pre > code.sourceCode { white-space: pre; position: relative; }
             pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
             pre > code.sourceCode > span:empty { height: 1.2em; }
+            .sourceCode { overflow: visible; }
             code.sourceCode > span { color: inherit; text-decoration: inherit; }
             div.sourceCode { margin: 1em 0; }
             pre.sourceCode { margin: 0; }
@@ -46,7 +47,7 @@
             code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
             code span.at { color: #7d9029; } /* Attribute */
             code span.bn { color: #40a070; } /* BaseN */
-            code span.bu { } /* BuiltIn */
+            code span.bu { color: #008000; } /* BuiltIn */
             code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
             code span.ch { color: #4070a0; } /* Char */
             code span.cn { color: #880000; } /* Constant */
@@ -59,7 +60,7 @@
             code span.ex { } /* Extension */
             code span.fl { color: #40a070; } /* Float */
             code span.fu { color: #06287e; } /* Function */
-            code span.im { } /* Import */
+            code span.im { color: #008000; font-weight: bold; } /* Import */
             code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
             code span.kw { color: #007020; font-weight: bold; } /* Keyword */
             code span.op { color: #666666; } /* Operator */
@@ -213,242 +214,810 @@
         
                     <div id="header">
                 <h1 class="title">This is the title of the thesis</h1>
-                                <h1 class="subtitle">This is the subtitle of the thesis</h1>
-                                                <h2 class="author">Firstname Surname</h2>
-                                                <h3 class="date">January 2015</h3>
+                                <h1 class="subtitle">This is the
+subtitle of the thesis</h1>
+                                                <h2 class="author">Firstname
+Surname</h2>
+                                                <h3 class="date">January
+2015</h3>
                             </div>
         
                     <div id="TOC">
                 <ul>
-                <li><a href="#abstract">Abstract</a></li>
-                <li><a href="#acknowledgements">Acknowledgements</a></li>
-                <li><a href="#abbreviations">Abbreviations</a></li>
-                <li><a href="#introduction-with-a-citation"><span class="toc-section-number">1</span> Introduction, with a citation</a>
+                <li><a href="#abstract"
+                id="toc-abstract">Abstract</a></li>
+                <li><a href="#acknowledgements"
+                id="toc-acknowledgements">Acknowledgements</a></li>
+                <li><span class="toc-section-number">1</span> List of
+                Figures</li>
+                <li><span class="toc-section-number">2</span> List of
+                Tables</li>
+                <li><a href="#abbreviations"
+                id="toc-abbreviations">Abbreviations</a></li>
+                <li><a href="#sec:intro" id="toc-sec:intro"><span
+                class="toc-section-number">3</span> Introduction, with a
+                citation</a>
                 <ul>
-                <li><a href="#background"><span class="toc-section-number">1.1</span> Background</a></li>
-                <li><a href="#the-middle-bit"><span class="toc-section-number">1.2</span> The middle bit</a>
+                <li><a href="#background" id="toc-background"><span
+                class="toc-section-number">3.1</span>
+                Background</a></li>
+                <li><a href="#the-middle-bit"
+                id="toc-the-middle-bit"><span
+                class="toc-section-number">3.2</span> The middle bit</a>
                 <ul>
-                <li><a href="#subsection-of-the-middle-bit"><span class="toc-section-number">1.2.1</span> Subsection of the middle bit</a></li>
+                <li><a href="#subsection-of-the-middle-bit"
+                id="toc-subsection-of-the-middle-bit"><span
+                class="toc-section-number">3.2.1</span> Subsection of
+                the middle bit</a></li>
                 </ul></li>
-                <li><a href="#summary-of-chapters"><span class="toc-section-number">1.3</span> Summary of chapters</a></li>
+                <li><a href="#summary-of-chapters"
+                id="toc-summary-of-chapters"><span
+                class="toc-section-number">3.3</span> Summary of
+                chapters</a></li>
                 </ul></li>
-                <li><a href="#literature-review-with-maths"><span class="toc-section-number">2</span> Literature review, with maths</a>
+                <li><a href="#sec:lit-review"
+                id="toc-sec:lit-review"><span
+                class="toc-section-number">4</span> Literature review,
+                with maths</a>
                 <ul>
-                <li><a href="#introduction"><span class="toc-section-number">2.1</span> Introduction</a></li>
-                <li><a href="#the-middle"><span class="toc-section-number">2.2</span> The middle</a></li>
-                <li><a href="#a-complicated-math-equation"><span class="toc-section-number">2.3</span> A complicated math equation</a></li>
-                <li><a href="#conclusion"><span class="toc-section-number">2.4</span> Conclusion</a></li>
+                <li><a href="#introduction" id="toc-introduction"><span
+                class="toc-section-number">4.1</span>
+                Introduction</a></li>
+                <li><a href="#the-middle" id="toc-the-middle"><span
+                class="toc-section-number">4.2</span> The
+                middle</a></li>
+                <li><a href="#a-complicated-math-equation"
+                id="toc-a-complicated-math-equation"><span
+                class="toc-section-number">4.3</span> A complicated math
+                equation</a></li>
+                <li><a href="#conclusion" id="toc-conclusion"><span
+                class="toc-section-number">4.4</span>
+                Conclusion</a></li>
                 </ul></li>
-                <li><a href="#first-research-study-with-code"><span class="toc-section-number">3</span> First research study, with code</a>
+                <li><a href="#sec:research-code"
+                id="toc-sec:research-code"><span
+                class="toc-section-number">5</span> First research
+                study, with code</a>
                 <ul>
-                <li><a href="#introduction-1"><span class="toc-section-number">3.1</span> Introduction</a></li>
-                <li><a href="#method"><span class="toc-section-number">3.2</span> Method</a>
+                <li><a href="#introduction-1"
+                id="toc-introduction-1"><span
+                class="toc-section-number">5.1</span>
+                Introduction</a></li>
+                <li><a href="#method" id="toc-method"><span
+                class="toc-section-number">5.2</span> Method</a>
                 <ul>
-                <li><a href="#subsection-1-with-example-code-block"><span class="toc-section-number">3.2.1</span> Subsection 1 with example code block</a></li>
-                <li><a href="#subsection-2"><span class="toc-section-number">3.2.2</span> Subsection 2</a></li>
+                <li><a href="#sec:subsec-code"
+                id="toc-sec:subsec-code"><span
+                class="toc-section-number">5.2.1</span> Subsection 1
+                with example code block</a></li>
+                <li><a href="#subsection-2" id="toc-subsection-2"><span
+                class="toc-section-number">5.2.2</span> Subsection
+                2</a></li>
                 </ul></li>
-                <li><a href="#results"><span class="toc-section-number">3.3</span> Results</a></li>
-                <li><a href="#discussion"><span class="toc-section-number">3.4</span> Discussion</a></li>
-                <li><a href="#conclusion-1"><span class="toc-section-number">3.5</span> Conclusion</a></li>
+                <li><a href="#results" id="toc-results"><span
+                class="toc-section-number">5.3</span> Results</a></li>
+                <li><a href="#discussion" id="toc-discussion"><span
+                class="toc-section-number">5.4</span>
+                Discussion</a></li>
+                <li><a href="#conclusion-1" id="toc-conclusion-1"><span
+                class="toc-section-number">5.5</span>
+                Conclusion</a></li>
                 </ul></li>
-                <li><a href="#research-containing-a-figure"><span class="toc-section-number">4</span> Research containing a figure</a>
+                <li><a href="#sec:research-figure"
+                id="toc-sec:research-figure"><span
+                class="toc-section-number">6</span> Research containing
+                a figure</a>
                 <ul>
-                <li><a href="#introduction-2"><span class="toc-section-number">4.1</span> Introduction</a></li>
-                <li><a href="#method-1"><span class="toc-section-number">4.2</span> Method</a>
+                <li><a href="#introduction-2"
+                id="toc-introduction-2"><span
+                class="toc-section-number">6.1</span>
+                Introduction</a></li>
+                <li><a href="#method-1" id="toc-method-1"><span
+                class="toc-section-number">6.2</span> Method</a>
                 <ul>
-                <li><a href="#subsection-1"><span class="toc-section-number">4.2.1</span> Subsection 1</a></li>
-                <li><a href="#subsection-2-1"><span class="toc-section-number">4.2.2</span> Subsection 2</a></li>
+                <li><a href="#subsection-1" id="toc-subsection-1"><span
+                class="toc-section-number">6.2.1</span> Subsection
+                1</a></li>
+                <li><a href="#subsection-2-1"
+                id="toc-subsection-2-1"><span
+                class="toc-section-number">6.2.2</span> Subsection
+                2</a></li>
                 </ul></li>
-                <li><a href="#results-1"><span class="toc-section-number">4.3</span> Results</a></li>
-                <li><a href="#discussion-1"><span class="toc-section-number">4.4</span> Discussion</a></li>
-                <li><a href="#conclusion-2"><span class="toc-section-number">4.5</span> Conclusion</a></li>
+                <li><a href="#results-1" id="toc-results-1"><span
+                class="toc-section-number">6.3</span> Results</a></li>
+                <li><a href="#discussion-1" id="toc-discussion-1"><span
+                class="toc-section-number">6.4</span>
+                Discussion</a></li>
+                <li><a href="#conclusion-2" id="toc-conclusion-2"><span
+                class="toc-section-number">6.5</span>
+                Conclusion</a></li>
                 </ul></li>
-                <li><a href="#research-containing-a-table"><span class="toc-section-number">5</span> Research containing a table</a>
+                <li><a href="#sec:research-table"
+                id="toc-sec:research-table"><span
+                class="toc-section-number">7</span> Research containing
+                a table</a>
                 <ul>
-                <li><a href="#introduction-3"><span class="toc-section-number">5.1</span> Introduction</a></li>
-                <li><a href="#method-2"><span class="toc-section-number">5.2</span> Method</a>
+                <li><a href="#introduction-3"
+                id="toc-introduction-3"><span
+                class="toc-section-number">7.1</span>
+                Introduction</a></li>
+                <li><a href="#method-2" id="toc-method-2"><span
+                class="toc-section-number">7.2</span> Method</a>
                 <ul>
-                <li><a href="#subsection-1-1"><span class="toc-section-number">5.2.1</span> Subsection 1</a></li>
-                <li><a href="#subsection-2-2"><span class="toc-section-number">5.2.2</span> Subsection 2</a></li>
+                <li><a href="#subsection-1-1"
+                id="toc-subsection-1-1"><span
+                class="toc-section-number">7.2.1</span> Subsection
+                1</a></li>
+                <li><a href="#subsection-2-2"
+                id="toc-subsection-2-2"><span
+                class="toc-section-number">7.2.2</span> Subsection
+                2</a></li>
                 </ul></li>
-                <li><a href="#results-2"><span class="toc-section-number">5.3</span> Results</a></li>
-                <li><a href="#discussion-2"><span class="toc-section-number">5.4</span> Discussion</a></li>
-                <li><a href="#conclusion-3"><span class="toc-section-number">5.5</span> Conclusion</a></li>
+                <li><a href="#results-2" id="toc-results-2"><span
+                class="toc-section-number">7.3</span> Results</a></li>
+                <li><a href="#discussion-2" id="toc-discussion-2"><span
+                class="toc-section-number">7.4</span>
+                Discussion</a></li>
+                <li><a href="#conclusion-3" id="toc-conclusion-3"><span
+                class="toc-section-number">7.5</span>
+                Conclusion</a></li>
                 </ul></li>
-                <li><a href="#final-research-study"><span class="toc-section-number">6</span> Final research study</a>
+                <li><a href="#sec:research-final"
+                id="toc-sec:research-final"><span
+                class="toc-section-number">8</span> Final research
+                study</a>
                 <ul>
-                <li><a href="#introduction-4"><span class="toc-section-number">6.1</span> Introduction</a></li>
-                <li><a href="#method-3"><span class="toc-section-number">6.2</span> Method</a>
+                <li><a href="#introduction-4"
+                id="toc-introduction-4"><span
+                class="toc-section-number">8.1</span>
+                Introduction</a></li>
+                <li><a href="#method-3" id="toc-method-3"><span
+                class="toc-section-number">8.2</span> Method</a>
                 <ul>
-                <li><a href="#subsection-1-2"><span class="toc-section-number">6.2.1</span> Subsection 1</a></li>
-                <li><a href="#subsection-2-3"><span class="toc-section-number">6.2.2</span> Subsection 2</a></li>
+                <li><a href="#subsection-1-2"
+                id="toc-subsection-1-2"><span
+                class="toc-section-number">8.2.1</span> Subsection
+                1</a></li>
+                <li><a href="#subsection-2-3"
+                id="toc-subsection-2-3"><span
+                class="toc-section-number">8.2.2</span> Subsection
+                2</a></li>
                 </ul></li>
-                <li><a href="#results-3"><span class="toc-section-number">6.3</span> Results</a></li>
-                <li><a href="#discussion-3"><span class="toc-section-number">6.4</span> Discussion</a></li>
-                <li><a href="#conclusion-4"><span class="toc-section-number">6.5</span> Conclusion</a></li>
+                <li><a href="#results-3" id="toc-results-3"><span
+                class="toc-section-number">8.3</span> Results</a></li>
+                <li><a href="#discussion-3" id="toc-discussion-3"><span
+                class="toc-section-number">8.4</span>
+                Discussion</a></li>
+                <li><a href="#conclusion-4" id="toc-conclusion-4"><span
+                class="toc-section-number">8.5</span>
+                Conclusion</a></li>
                 </ul></li>
-                <li><a href="#conclusion-5"><span class="toc-section-number">7</span> Conclusion</a>
+                <li><a href="#sec:conclusion"
+                id="toc-sec:conclusion"><span
+                class="toc-section-number">9</span> Conclusion</a>
                 <ul>
-                <li><a href="#thesis-summary"><span class="toc-section-number">7.1</span> Thesis summary</a></li>
-                <li><a href="#future-work"><span class="toc-section-number">7.2</span> Future work</a></li>
+                <li><a href="#thesis-summary"
+                id="toc-thesis-summary"><span
+                class="toc-section-number">9.1</span> Thesis
+                summary</a></li>
+                <li><a href="#future-work" id="toc-future-work"><span
+                class="toc-section-number">9.2</span> Future
+                work</a></li>
                 </ul></li>
-                <li><a href="#appendix-1-some-extra-stuff">Appendix 1: Some extra stuff</a></li>
-                <li><a href="#appendix-2-some-more-extra-stuff">Appendix 2: Some more extra stuff</a></li>
-                <li><a href="#references">References</a></li>
+                <li><a href="#appendix-1-some-extra-stuff"
+                id="toc-appendix-1-some-extra-stuff">Appendix 1: Some
+                extra stuff</a></li>
+                <li><a href="#appendix-2-some-more-extra-stuff"
+                id="toc-appendix-2-some-more-extra-stuff">Appendix 2:
+                Some more extra stuff</a></li>
+                <li><a href="#references"
+                id="toc-references">References</a></li>
                 </ul>
             </div>
                                 <!-- This page is for an official declaration. -->
-                                <p>    </p>
-                                <h1 class="unnumbered" id="abstract">Abstract</h1>
+                                <p> </p>
+                                <h1 class="unnumbered"
+                                id="abstract">Abstract</h1>
                                 <!-- This is the abstract -->
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam et turpis gravida, lacinia ante sit amet, sollicitudin erat. Aliquam efficitur vehicula leo sed condimentum. Phasellus lobortis eros vitae rutrum egestas. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec at urna imperdiet, vulputate orci eu, sollicitudin leo. Donec nec dui sagittis, malesuada erat eget, vulputate tellus. Nam ullamcorper efficitur iaculis. Mauris eu vehicula nibh. In lectus turpis, tempor at felis a, egestas fermentum massa.</p>
-                                <h1 class="unnumbered" id="acknowledgements">Acknowledgements</h1>
+                                <p>Lorem ipsum dolor sit amet,
+                                consectetur adipiscing elit. Nam et
+                                turpis gravida, lacinia ante sit amet,
+                                sollicitudin erat. Aliquam efficitur
+                                vehicula leo sed condimentum. Phasellus
+                                lobortis eros vitae rutrum egestas.
+                                Vestibulum ante ipsum primis in faucibus
+                                orci luctus et ultrices posuere cubilia
+                                Curae; Donec at urna imperdiet,
+                                vulputate orci eu, sollicitudin leo.
+                                Donec nec dui sagittis, malesuada erat
+                                eget, vulputate tellus. Nam ullamcorper
+                                efficitur iaculis. Mauris eu vehicula
+                                nibh. In lectus turpis, tempor at felis
+                                a, egestas fermentum massa.</p>
+                                <h1 class="unnumbered"
+                                id="acknowledgements">Acknowledgements</h1>
                                 <!-- This is for acknowledging all of the people who helped out -->
-                                <p>Interdum et malesuada fames ac ante ipsum primis in faucibus. Aliquam congue fermentum ante, semper porta nisl consectetur ut. Duis ornare sit amet dui ac faucibus. Phasellus ullamcorper leo vitae arcu ultricies cursus. Duis tristique lacus eget metus bibendum, at dapibus ante malesuada. In dictum nulla nec porta varius. Fusce et elit eget sapien fringilla maximus in sit amet dui.</p>
-                                <p>Mauris eget blandit nisi, faucibus imperdiet odio. Suspendisse blandit dolor sed tellus venenatis, venenatis fringilla turpis pretium. Donec pharetra arcu vitae euismod tincidunt. Morbi ut turpis volutpat, ultrices felis non, finibus justo. Proin convallis accumsan sem ac vulputate. Sed rhoncus ipsum eu urna placerat, sed rhoncus erat facilisis. Praesent vitae vestibulum dui. Proin interdum tellus ac velit varius, sed finibus turpis placerat.</p>
+                                <p>Interdum et malesuada fames ac ante
+                                ipsum primis in faucibus. Aliquam congue
+                                fermentum ante, semper porta nisl
+                                consectetur ut. Duis ornare sit amet dui
+                                ac faucibus. Phasellus ullamcorper leo
+                                vitae arcu ultricies cursus. Duis
+                                tristique lacus eget metus bibendum, at
+                                dapibus ante malesuada. In dictum nulla
+                                nec porta varius. Fusce et elit eget
+                                sapien fringilla maximus in sit amet
+                                dui.</p>
+                                <p>Mauris eget blandit nisi, faucibus
+                                imperdiet odio. Suspendisse blandit
+                                dolor sed tellus venenatis, venenatis
+                                fringilla turpis pretium. Donec pharetra
+                                arcu vitae euismod tincidunt. Morbi ut
+                                turpis volutpat, ultrices felis non,
+                                finibus justo. Proin convallis accumsan
+                                sem ac vulputate. Sed rhoncus ipsum eu
+                                urna placerat, sed rhoncus erat
+                                facilisis. Praesent vitae vestibulum
+                                dui. Proin interdum tellus ac velit
+                                varius, sed finibus turpis placerat.</p>
                                 <!-- Use the \newpage command to force a new page -->
-                                <!-- 
+                                <h1 data-number="1"><span
+                                class="header-section-number">1</span>
+                                List of Figures</h1>
+                                <div class="list list-of-fig">
+                                1. RV Calypso is a former British Royal
+                                Navy minesweeper converted into a
+                                research vessel for the oceanographic
+                                researcher Jacques-Yves Cousteau. It was
+                                equipped with a mobile laboratory for
+                                underwater field research.<br />
+
+                                2. This is not a boat<br />
+
+                                </div>
+                                <!--
                                 The \listoffigures will use short captions first, and the whole caption if none is present. To keep this list readable, ensure each figure has a short caption, e.g.
-                                ![main_text_caption](source/figures/my_image.pdf "short caption used in alt text and \listoffigures"){#fig:mylabel}{ width=50% }
+                                ![main_text_caption](source/figures/my_image.pdf ){#fig:mylabel}{ width=50% short-caption="short caption"}
 
                                 See chapter 4 for more examples.
                                 -->
-                                <h1 class="unnumbered" id="abbreviations">Abbreviations</h1>
+                                <h1 data-number="2"><span
+                                class="header-section-number">2</span>
+                                List of Tables</h1>
+                                <div class="list list-of-tbl">
 
-                                <h1 data-number="1" id="introduction-with-a-citation"><span class="header-section-number">1</span> Introduction, with a citation</h1>
-                                <h2 data-number="1.1" id="background"><span class="header-section-number">1.1</span> Background</h2>
-                                <p>This is the introduction. Quisque finibus aliquet cursus. Integer in pellentesque tellus. Duis eu dignissim nulla, a porttitor enim. Quisque vehicula leo non ultrices finibus. Duis vehicula quis sem sit amet sollicitudin. Integer neque est, pharetra et auctor vel, iaculis interdum lectus.</p>
+                                </div>
+                                <!--
+                                The \listoffigures will use short captions first, and the whole caption if none is present. To keep this list readable, ensure each figure has a short caption, e.g.
+
+                                +----------+----------+----------+
+                                |   Test   |  Test2   |  Test3   |
+                                +----------+----------+----------+
+                                |    20    |    22    |    23    |
+                                +----------+----------+----------+
+                                |    34    |    35    |    36    |
+                                +----------+----------+----------+
+                                :  Long caption []{#tbl:tbl_ref short-caption="short caption"}
+
+                                You MUST include the empty square brackets before the curly brackets.
+
+                                See chapter 5 for more examples.
+                                -->
+                                <h1 class="unnumbered"
+                                id="abbreviations">Abbreviations</h1>
+
+                                <h1 data-number="3" id="sec:intro"><span
+                                class="header-section-number">3</span>
+                                Introduction, with a citation</h1>
+                                <h2 data-number="3.1"
+                                id="background"><span
+                                class="header-section-number">3.1</span>
+                                Background</h2>
+                                <p>This is the introduction. Quisque
+                                finibus aliquet cursus. Integer in
+                                pellentesque tellus. Duis eu dignissim
+                                nulla, a porttitor enim. Quisque
+                                vehicula leo non ultrices finibus. Duis
+                                vehicula quis sem sit amet sollicitudin.
+                                Integer neque est, pharetra et auctor
+                                vel, iaculis interdum lectus.</p>
                                 <!-- 
                                 To include a reference, add the citation key shown in the references.bib file.
                                 -->
-                                <p>To include a citation to the text, just add the citation key shown in the references.bib file. The style of the citation is determined by the ref_format.csl file. For example, in The Living Sea you can find pictures of the Calypso <span class="citation" data-cites="Cousteau1963">(Cousteau Jacques &amp; Dugan James 1963)</span>.</p>
-                                <p>In neque mauris, maximus at sapien a, iaculis dignissim justo. Aliquam erat volutpat. Praesent varius risus auctor est ultricies, sit amet consequat nisi laoreet. Suspendisse non est et mauris pharetra sagittis non porta justo. Praesent malesuada metus ut sapien sodales ornare.</p>
-                                <h2 data-number="1.2" id="the-middle-bit"><span class="header-section-number">1.2</span> The middle bit</h2>
-                                <p>This is the middle bit. Phasellus quis ex in ipsum pellentesque lobortis tincidunt sed massa. Nullam euismod sem quis dictum condimentum. Suspendisse risus metus, elementum eu congue quis, viverra ac metus. Donec non lectus at lectus euismod laoreet pharetra semper dui. Donec sed eleifend erat, vel ultrices nibh. Nam scelerisque turpis ac nunc mollis, et rutrum nisl luctus.</p>
-                                <p>Duis faucibus vestibulum elit, sit amet lobortis libero. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed at cursus nibh. Sed accumsan imperdiet interdum. Proin id facilisis tortor. Proin posuere a neque nec iaculis. Suspendisse potenti. Nullam hendrerit ante mi, vitae iaculis dui laoreet eu.</p>
-                                <p>Cras eleifend velit diam, eu viverra mi volutpat ut. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec finibus leo nec dui imperdiet, tincidunt ornare orci venenatis. Maecenas placerat efficitur est, eu blandit magna hendrerit eu.</p>
-                                <h3 data-number="1.2.1" id="subsection-of-the-middle-bit"><span class="header-section-number">1.2.1</span> Subsection of the middle bit</h3>
-                                <p>This is a subsection of the middle bit. Quisque sit amet tempus arcu, ac suscipit ante. Cras massa elit, pellentesque eget nisl ut, malesuada rutrum risus. Nunc in venenatis mi. Curabitur sit amet suscipit eros, non tincidunt nibh. Phasellus lorem lectus, iaculis non luctus eget, tempus non risus. Suspendisse ut felis mi.</p>
-                                <h2 data-number="1.3" id="summary-of-chapters"><span class="header-section-number">1.3</span> Summary of chapters</h2>
-                                <!-- 
+                                <p>To include a citation to the text,
+                                just add the citation key shown in the
+                                references.bib file. The style of the
+                                citation is determined by the
+                                ref_format.csl file. For example, in The
+                                Living Sea you can find pictures of the
+                                Calypso <span class="citation"
+                                data-cites="Cousteau1963">(Cousteau
+                                Jacques &amp; Dugan James
+                                1963)</span>.</p>
+                                <p>In neque mauris, maximus at sapien a,
+                                iaculis dignissim justo. Aliquam erat
+                                volutpat. Praesent varius risus auctor
+                                est ultricies, sit amet consequat nisi
+                                laoreet. Suspendisse non est et mauris
+                                pharetra sagittis non porta justo.
+                                Praesent malesuada metus ut sapien
+                                sodales ornare.</p>
+                                <h2 data-number="3.2"
+                                id="the-middle-bit"><span
+                                class="header-section-number">3.2</span>
+                                The middle bit</h2>
+                                <p>This is the middle bit. Phasellus
+                                quis ex in ipsum pellentesque lobortis
+                                tincidunt sed massa. Nullam euismod sem
+                                quis dictum condimentum. Suspendisse
+                                risus metus, elementum eu congue quis,
+                                viverra ac metus. Donec non lectus at
+                                lectus euismod laoreet pharetra semper
+                                dui. Donec sed eleifend erat, vel
+                                ultrices nibh. Nam scelerisque turpis ac
+                                nunc mollis, et rutrum nisl luctus.</p>
+                                <p>Duis faucibus vestibulum elit, sit
+                                amet lobortis libero. Class aptent
+                                taciti sociosqu ad litora torquent per
+                                conubia nostra, per inceptos himenaeos.
+                                Sed at cursus nibh. Sed accumsan
+                                imperdiet interdum. Proin id facilisis
+                                tortor. Proin posuere a neque nec
+                                iaculis. Suspendisse potenti. Nullam
+                                hendrerit ante mi, vitae iaculis dui
+                                laoreet eu.</p>
+                                <p>Cras eleifend velit diam, eu viverra
+                                mi volutpat ut. Cum sociis natoque
+                                penatibus et magnis dis parturient
+                                montes, nascetur ridiculus mus. Donec
+                                finibus leo nec dui imperdiet, tincidunt
+                                ornare orci venenatis. Maecenas placerat
+                                efficitur est, eu blandit magna
+                                hendrerit eu.</p>
+                                <h3 data-number="3.2.1"
+                                id="subsection-of-the-middle-bit"><span
+                                class="header-section-number">3.2.1</span>
+                                Subsection of the middle bit</h3>
+                                <p>This is a subsection of the middle
+                                bit. Quisque sit amet tempus arcu, ac
+                                suscipit ante. Cras massa elit,
+                                pellentesque eget nisl ut, malesuada
+                                rutrum risus. Nunc in venenatis mi.
+                                Curabitur sit amet suscipit eros, non
+                                tincidunt nibh. Phasellus lorem lectus,
+                                iaculis non luctus eget, tempus non
+                                risus. Suspendisse ut felis mi.</p>
+                                <h2 data-number="3.3"
+                                id="summary-of-chapters"><span
+                                class="header-section-number">3.3</span>
+                                Summary of chapters</h2>
+                                <!--
                                 For italic, add _ on either side of the text
                                 For bold, add ** on either side of the text
                                 For bold and italic, add _** on either side of the text
                                 -->
-                                <p>This is a brief outline of what went into each chapter, and a section which shows how to reference headers (which are labelled automatically for you). This chapter, section <a href="#introduction-with-a-citation">1</a>, shows how to use citations and how to reference section headers. Section <a href="#literature-review-with-maths">2</a> shows how use and reference equations. Section <a href="#first-research-study-with-code">3</a> shows how to use and reference code. Section <a href="#research-containing-a-figure">4</a> shows how to use, reference, and resize pdf and jpg figures. Section <a href="#research-containing-a-table">5</a> shows how to use and reference tables. Section <a href="#final-research-study">6</a> is truly revolutionary (but shows nothing functional). <strong><a href="#appendix-1-some-extra-stuff">Appendix 1</a></strong> shows how to add chapters which are not numbered, and has to be referenced manually, as does <strong><a href="#appendix-2-some-more-extra-stuff">Appendix 2</a></strong>. See the base <a href="https://github.com/tompollard/phd_thesis_markdown/blob/master/README.md"><code>README.md</code></a> for how References are handled - leave <code>*_references.md</code> alone, and provide it to <code>pandoc</code> last.</p>
-                                <p>Proin faucibus nibh sit amet augue blandit varius.</p>
-                                <h1 data-number="2" id="literature-review-with-maths"><span class="header-section-number">2</span> Literature review, with maths</h1>
+                                <p>This is a brief outline of what went
+                                into each chapter, and a section which
+                                shows how to reference headers (which
+                                are labelled automatically for you).
+                                This chapter, Section 1, shows how to
+                                use citations and how to reference
+                                section headers. Section 2 shows how use
+                                and reference equations. Section 3 shows
+                                how to use and reference code. Section 4
+                                shows how to use, reference, and resize
+                                pdf and jpg figures. Section 5 shows how
+                                to use and reference tables. Section 6
+                                is truly revolutionary (but shows
+                                nothing functional). <strong><a
+                                href="#appendix-1-some-extra-stuff">Appendix
+                                1</a></strong> shows how to add chapters
+                                which are not numbered, and has to be
+                                referenced manually, as does <strong><a
+                                href="#appendix-2-some-more-extra-stuff">Appendix
+                                2</a></strong>. See the base <a
+                                href="https://github.com/tompollard/phd_thesis_markdown/blob/master/README.md"><code>README.md</code></a>
+                                for how References are handled - leave
+                                <code>*_references.md</code> alone, and
+                                provide it to <code>pandoc</code>
+                                last.</p>
+                                <p>Proin faucibus nibh sit amet augue
+                                blandit varius.</p>
+                                <h1 data-number="4"
+                                id="sec:lit-review"><span
+                                class="header-section-number">4</span>
+                                Literature review, with maths</h1>
                                 <!--
-                                After the introductory chapter, it seems fairly common to 
-                                include a chapter that reviews the literature and 
+                                After the introductory chapter, it seems fairly common to
+                                include a chapter that reviews the literature and
                                 introduces methodology used throughout the thesis.
                                 -->
-                                <h2 data-number="2.1" id="introduction"><span class="header-section-number">2.1</span> Introduction</h2>
-                                <p>This is the introduction. Duis in neque felis. In hac habitasse platea dictumst. Cras eget rutrum elit. Pellentesque tristique venenatis pellentesque. Cras eu dignissim quam, vel sodales felis. Vestibulum efficitur justo a nibh cursus eleifend. Integer ultrices lorem at nunc efficitur lobortis.</p>
-                                <h2 data-number="2.2" id="the-middle"><span class="header-section-number">2.2</span> The middle</h2>
-                                <p>This is the literature review. Nullam quam odio, volutpat ac ornare quis, vestibulum nec nulla. Aenean nec dapibus in mL/min<sup>-1</sup>. Mathematical formula can be inserted using Latex and can be automatically numbered:</p>
-                                <p><span id="eq:my_equation" class="eqnos"><span class="math inline"><em>f</em>(<em>x</em>) = <em>a</em><em>x</em><sup>3</sup> + <em>b</em><em>x</em><sup>2</sup> + <em>c</em><em>x</em> + <em>d</em></span><span class="eqnos-number">(1)</span></span> </p>
-                                <p>Nunc eleifend, ex a luctus porttitor, felis ex suscipit tellus, ut sollicitudin sapien purus in libero. Nulla blandit eget urna vel tempus. Praesent fringilla dui sapien, sit amet egestas leo sollicitudin at.</p>
-                                <p>Later on in the text, you can reference Equation <a href="#eq:my_equation">1</a> and its mind-blowing ramifications. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed faucibus pulvinar volutpat. Ut semper fringilla erat non dapibus. Nunc vitae felis eget purus placerat finibus laoreet ut nibh.</p>
-                                <h2 data-number="2.3" id="a-complicated-math-equation"><span class="header-section-number">2.3</span> A complicated math equation</h2>
-                                <p>The following raw text in markdown behind Equation <a href="#eq:my_complicated_equation">2</a> shows that you can fall back on if it is more convenient for you. Note that this will only be rendered in <code>thesis.pdf</code></p>
-                                <p><span id="eq:my_complicated_equation" class="eqnos"><span class="math display">$$
+                                <h2 data-number="4.1"
+                                id="introduction"><span
+                                class="header-section-number">4.1</span>
+                                Introduction</h2>
+                                <p>This is the introduction. Duis in
+                                neque felis. In hac habitasse platea
+                                dictumst. Cras eget rutrum elit.
+                                Pellentesque tristique venenatis
+                                pellentesque. Cras eu dignissim quam,
+                                vel sodales felis. Vestibulum efficitur
+                                justo a nibh cursus eleifend. Integer
+                                ultrices lorem at nunc efficitur
+                                lobortis.</p>
+                                <h2 data-number="4.2"
+                                id="the-middle"><span
+                                class="header-section-number">4.2</span>
+                                The middle</h2>
+                                <p>This is the literature review. Nullam
+                                quam odio, volutpat ac ornare quis,
+                                vestibulum nec nulla. Aenean nec dapibus
+                                in mL/min<sup>-1</sup>. Mathematical
+                                formula can be inserted using Latex and
+                                can be automatically numbered:</p>
+                                <p><span id="eq:my_equation"><span
+                                class="math display"><em>f</em>(<em>x</em>) = <em>a</em><em>x</em><sup>3</sup> + <em>b</em><em>x</em><sup>2</sup> + <em>c</em><em>x</em> + <em>d</em>   (1)</span></span></p>
+                                <p>Nunc eleifend, ex a luctus porttitor,
+                                felis ex suscipit tellus, ut
+                                sollicitudin sapien purus in libero.
+                                Nulla blandit eget urna vel tempus.
+                                Praesent fringilla dui sapien, sit amet
+                                egestas leo sollicitudin at.</p>
+                                <p>Later on in the text, you can
+                                reference Equation 1 and its
+                                mind-blowing ramifications. Pellentesque
+                                habitant morbi tristique senectus et
+                                netus et malesuada fames ac turpis
+                                egestas. Sed faucibus pulvinar volutpat.
+                                Ut semper fringilla erat non dapibus.
+                                Nunc vitae felis eget purus placerat
+                                finibus laoreet ut nibh.</p>
+                                <h2 data-number="4.3"
+                                id="a-complicated-math-equation"><span
+                                class="header-section-number">4.3</span>
+                                A complicated math equation</h2>
+                                <p>The following raw text in markdown
+                                behind Equation 2 shows that you can
+                                fall back on if it is more convenient
+                                for you. Note that this will only be
+                                rendered in <code>thesis.pdf</code></p>
+                                <p><span
+                                id="eq:my_complicated_equation"><span
+                                class="math display">$$
                                 \begin{aligned}
-                                    \hat{\theta}_g = \argmin_{\theta_g} \Big\{ - &amp;\sum^{N}_{n=1}\Big( 1-\mathbb{1}[f(\pmb x^{(n)})]\Big)\log f\Big(\pmb x^{(n)} \\ 
-                                    &amp;+ g(\pmb x^{(n)};\theta_g)\Big) + \lambda|g(\pmb x^{(n)};\theta_g)|_2 \Big\} \ ,
+                                    \hat{\theta}_g = \argmin_{\theta_g}
+                                \Big\{ - &amp;\sum^{N}_{n=1}\Big(
+                                1-\mathbb{1}[f(\pmb x^{(n)})]\Big)\log
+                                f\Big(\pmb x^{(n)} \\
+                                    &amp;+ g(\pmb x^{(n)};\theta_g)\Big)
+                                + \lambda|g(\pmb x^{(n)};\theta_g)|_2
+                                \Big\} \ ,
                                 \end{aligned}
-                                $$</span><span class="eqnos-number">(2)</span></span> </p>
-                                <h2 data-number="2.4" id="conclusion"><span class="header-section-number">2.4</span> Conclusion</h2>
-                                <p>This is the conclusion. Donec pulvinar molestie urna eu faucibus. In tristique ut neque vel eleifend. Morbi ut massa vitae diam gravida iaculis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
+                                \qquad{(2)}$$</span></span></p>
+                                <h2 data-number="4.4"
+                                id="conclusion"><span
+                                class="header-section-number">4.4</span>
+                                Conclusion</h2>
+                                <p>This is the conclusion. Donec
+                                pulvinar molestie urna eu faucibus. In
+                                tristique ut neque vel eleifend. Morbi
+                                ut massa vitae diam gravida iaculis.
+                                Pellentesque habitant morbi tristique
+                                senectus et netus et malesuada fames ac
+                                turpis egestas.</p>
                                 <!-- Insert an unordered list -->
                                 <ul>
                                 <li>first item in the list</li>
                                 <li>second item in the list</li>
                                 <li>third item in the list</li>
                                 </ul>
-                                <h1 data-number="3" id="first-research-study-with-code"><span class="header-section-number">3</span> First research study, with code</h1>
-                                <h2 data-number="3.1" id="introduction-1"><span class="header-section-number">3.1</span> Introduction</h2>
-                                <p>This is the introduction. Nam mollis congue tortor, sit amet convallis tortor mollis eget. Fusce viverra ut magna eu sagittis. Vestibulum at ultrices sapien, at elementum urna. Nam a blandit leo, non lobortis quam. Aliquam feugiat turpis vitae tincidunt ultricies. Mauris ullamcorper pellentesque nisl, vel molestie lorem viverra at.</p>
-                                <h2 data-number="3.2" id="method"><span class="header-section-number">3.2</span> Method</h2>
-                                <p>Suspendisse iaculis in lacus ut dignissim. Cras dignissim dictum eleifend. Suspendisse potenti. Suspendisse et nisi suscipit, vestibulum est at, maximus sapien. Sed ut diam tortor.</p>
-                                <h3 data-number="3.2.1" id="subsection-1-with-example-code-block"><span class="header-section-number">3.2.1</span> Subsection 1 with example code block</h3>
-                                <p>This is the first part of the methodology. Cras porta dui a dolor tincidunt placerat. Cras scelerisque sem et malesuada vestibulum. Vivamus faucibus ligula ac sodales consectetur. Aliquam vel tristique nisl. Aliquam erat volutpat. Pellentesque iaculis enim sit amet posuere facilisis. Integer egestas quam sit amet nunc maximus, id bibendum ex blandit.</p>
-                                <p>For syntax highlighting in code blocks, add three “`” characters before and after a code block:</p>
-                                <div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>mood <span class="op">=</span> <span class="st">&#39;happy&#39;</span></span>
-                                <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> mood <span class="op">==</span> <span class="st">&#39;happy&#39;</span>:</span>
-                                <span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span>(<span class="st">&quot;I am a happy robot&quot;</span>)</span></code></pre></div>
-                                <h3 data-number="3.2.2" id="subsection-2"><span class="header-section-number">3.2.2</span> Subsection 2</h3>
-                                <p>By running the code in section <a href="#subsection-1-with-example-code-block">3.2.1</a>, we solved AI completely. This is the second part of the methodology. Proin tincidunt odio non sem mollis tristique. Fusce pharetra accumsan volutpat. In nec mauris vel orci rutrum dapibus nec ac nibh. Praesent malesuada sagittis nulla, eget commodo mauris ultricies eget. Suspendisse iaculis finibus ligula.</p>
+                                <h1 data-number="5"
+                                id="sec:research-code"><span
+                                class="header-section-number">5</span>
+                                First research study, with code</h1>
+                                <h2 data-number="5.1"
+                                id="introduction-1"><span
+                                class="header-section-number">5.1</span>
+                                Introduction</h2>
+                                <p>This is the introduction. Nam mollis
+                                congue tortor, sit amet convallis tortor
+                                mollis eget. Fusce viverra ut magna eu
+                                sagittis. Vestibulum at ultrices sapien,
+                                at elementum urna. Nam a blandit leo,
+                                non lobortis quam. Aliquam feugiat
+                                turpis vitae tincidunt ultricies. Mauris
+                                ullamcorper pellentesque nisl, vel
+                                molestie lorem viverra at.</p>
+                                <h2 data-number="5.2" id="method"><span
+                                class="header-section-number">5.2</span>
+                                Method</h2>
+                                <p>Suspendisse iaculis in lacus ut
+                                dignissim. Cras dignissim dictum
+                                eleifend. Suspendisse potenti.
+                                Suspendisse et nisi suscipit, vestibulum
+                                est at, maximus sapien. Sed ut diam
+                                tortor.</p>
+                                <h3 data-number="5.2.1"
+                                id="sec:subsec-code"><span
+                                class="header-section-number">5.2.1</span>
+                                Subsection 1 with example code
+                                block</h3>
+                                <p>This is the first part of the
+                                methodology. Cras porta dui a dolor
+                                tincidunt placerat. Cras scelerisque sem
+                                et malesuada vestibulum. Vivamus
+                                faucibus ligula ac sodales consectetur.
+                                Aliquam vel tristique nisl. Aliquam erat
+                                volutpat. Pellentesque iaculis enim sit
+                                amet posuere facilisis. Integer egestas
+                                quam sit amet nunc maximus, id bibendum
+                                ex blandit.</p>
+                                <p>For syntax highlighting in code
+                                blocks, add three “`” characters before
+                                and after a code block:</p>
+                                <div id="lst:code"
+                                class="listing python">
+                                <p>Listing 1: Code caption</p>
+                                <div class="sourceCode" id="cb1"><pre
+                                class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>mood <span class="op">=</span> <span class="st">&#39;happy&#39;</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> mood <span class="op">==</span> <span class="st">&#39;happy&#39;</span>:</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span>(<span class="st">&quot;I am a happy robot&quot;</span>)</span></code></pre></div>
+                                </div>
+                                <p>You can then reference the code block
+                                like this (Listing 1).</p>
+                                <h3 data-number="5.2.2"
+                                id="subsection-2"><span
+                                class="header-section-number">5.2.2</span>
+                                Subsection 2</h3>
+                                <p>By running the code in Section 3.2.1,
+                                we solved AI completely. This is the
+                                second part of the methodology. Proin
+                                tincidunt odio non sem mollis tristique.
+                                Fusce pharetra accumsan volutpat. In nec
+                                mauris vel orci rutrum dapibus nec ac
+                                nibh. Praesent malesuada sagittis nulla,
+                                eget commodo mauris ultricies eget.
+                                Suspendisse iaculis finibus ligula.</p>
                                 <!-- 
                                 Comments can be added like this.
                                 -->
-                                <h2 data-number="3.3" id="results"><span class="header-section-number">3.3</span> Results</h2>
-                                <p>These are the results. Ut accumsan tempus aliquam. Sed massa ex, egestas non libero id, imperdiet scelerisque augue. Duis rutrum ultrices arcu et ultricies. Proin vel elit eu magna mattis vehicula. Sed ex erat, fringilla vel feugiat ut, fringilla non diam.</p>
-                                <h2 data-number="3.4" id="discussion"><span class="header-section-number">3.4</span> Discussion</h2>
-                                <p>This is the discussion. Duis ultrices tempor sem vitae convallis. Pellentesque lobortis risus ac nisi varius bibendum. Phasellus volutpat aliquam varius. Mauris vitae neque quis libero volutpat finibus. Nunc diam metus, imperdiet vitae leo sed, varius posuere orci.</p>
-                                <h2 data-number="3.5" id="conclusion-1"><span class="header-section-number">3.5</span> Conclusion</h2>
-                                <p>This is the conclusion to the chapter. Praesent bibendum urna orci, a venenatis tellus venenatis at. Etiam ornare, est sed lacinia elementum, lectus diam tempor leo, sit amet elementum ex elit id ex. Ut ac viverra turpis. Quisque in nisl auctor, ornare dui ac, consequat tellus.</p>
-                                <h1 data-number="4" id="research-containing-a-figure"><span class="header-section-number">4</span> Research containing a figure</h1>
-                                <h2 data-number="4.1" id="introduction-2"><span class="header-section-number">4.1</span> Introduction</h2>
-                                <p>This is the introduction. Sed vulputate tortor at nisl blandit interdum. Cras sagittis massa ex, quis eleifend purus condimentum congue. Maecenas tristique, justo vitae efficitur mollis, mi nulla varius elit, in consequat ligula nulla ut augue. Phasellus diam sapien, placerat sit amet tempor non, lobortis tempus ante.</p>
-                                <h2 data-number="4.2" id="method-1"><span class="header-section-number">4.2</span> Method</h2>
-                                <p>Donec imperdiet, lectus vestibulum sagittis tempus, turpis dolor euismod justo, vel tempus neque libero sit amet tortor. Nam cursus commodo tincidunt.</p>
-                                <h3 data-number="4.2.1" id="subsection-1"><span class="header-section-number">4.2.1</span> Subsection 1</h3>
-                                <p>This is the first part of the methodology. Duis tempor sapien sed tellus ultrices blandit. Sed porta mauris tortor, eu vulputate arcu dapibus ac. Curabitur sodales at felis efficitur sollicitudin. Quisque at neque sollicitudin, mollis arcu vitae, faucibus tellus.</p>
-                                <h3 data-number="4.2.2" id="subsection-2-1"><span class="header-section-number">4.2.2</span> Subsection 2</h3>
-                                <p>This is the second part of the methodology. Sed ut ipsum ultrices, interdum ipsum vel, lobortis diam. Curabitur sit amet massa quis tortor molestie dapibus a at libero. Mauris mollis magna quis ante vulputate consequat. Integer leo turpis, suscipit ac venenatis pellentesque, efficitur non sem. Pellentesque eget vulputate turpis. Etiam id nibh at elit fermentum interdum.</p>
+                                <h2 data-number="5.3" id="results"><span
+                                class="header-section-number">5.3</span>
+                                Results</h2>
+                                <p>These are the results. Ut accumsan
+                                tempus aliquam. Sed massa ex, egestas
+                                non libero id, imperdiet scelerisque
+                                augue. Duis rutrum ultrices arcu et
+                                ultricies. Proin vel elit eu magna
+                                mattis vehicula. Sed ex erat, fringilla
+                                vel feugiat ut, fringilla non diam.</p>
+                                <h2 data-number="5.4"
+                                id="discussion"><span
+                                class="header-section-number">5.4</span>
+                                Discussion</h2>
+                                <p>This is the discussion. Duis ultrices
+                                tempor sem vitae convallis. Pellentesque
+                                lobortis risus ac nisi varius bibendum.
+                                Phasellus volutpat aliquam varius.
+                                Mauris vitae neque quis libero volutpat
+                                finibus. Nunc diam metus, imperdiet
+                                vitae leo sed, varius posuere orci.</p>
+                                <h2 data-number="5.5"
+                                id="conclusion-1"><span
+                                class="header-section-number">5.5</span>
+                                Conclusion</h2>
+                                <p>This is the conclusion to the
+                                chapter. Praesent bibendum urna orci, a
+                                venenatis tellus venenatis at. Etiam
+                                ornare, est sed lacinia elementum,
+                                lectus diam tempor leo, sit amet
+                                elementum ex elit id ex. Ut ac viverra
+                                turpis. Quisque in nisl auctor, ornare
+                                dui ac, consequat tellus.</p>
+                                <h1 data-number="6"
+                                id="sec:research-figure"><span
+                                class="header-section-number">6</span>
+                                Research containing a figure</h1>
+                                <h2 data-number="6.1"
+                                id="introduction-2"><span
+                                class="header-section-number">6.1</span>
+                                Introduction</h2>
+                                <p>This is the introduction. Sed
+                                vulputate tortor at nisl blandit
+                                interdum. Cras sagittis massa ex, quis
+                                eleifend purus condimentum congue.
+                                Maecenas tristique, justo vitae
+                                efficitur mollis, mi nulla varius elit,
+                                in consequat ligula nulla ut augue.
+                                Phasellus diam sapien, placerat sit amet
+                                tempor non, lobortis tempus ante.</p>
+                                <h2 data-number="6.2"
+                                id="method-1"><span
+                                class="header-section-number">6.2</span>
+                                Method</h2>
+                                <p>Donec imperdiet, lectus vestibulum
+                                sagittis tempus, turpis dolor euismod
+                                justo, vel tempus neque libero sit amet
+                                tortor. Nam cursus commodo
+                                tincidunt.</p>
+                                <h3 data-number="6.2.1"
+                                id="subsection-1"><span
+                                class="header-section-number">6.2.1</span>
+                                Subsection 1</h3>
+                                <p>This is the first part of the
+                                methodology. Duis tempor sapien sed
+                                tellus ultrices blandit. Sed porta
+                                mauris tortor, eu vulputate arcu dapibus
+                                ac. Curabitur sodales at felis efficitur
+                                sollicitudin. Quisque at neque
+                                sollicitudin, mollis arcu vitae,
+                                faucibus tellus.</p>
+                                <h3 data-number="6.2.2"
+                                id="subsection-2-1"><span
+                                class="header-section-number">6.2.2</span>
+                                Subsection 2</h3>
+                                <p>This is the second part of the
+                                methodology. Sed ut ipsum ultrices,
+                                interdum ipsum vel, lobortis diam.
+                                Curabitur sit amet massa quis tortor
+                                molestie dapibus a at libero. Mauris
+                                mollis magna quis ante vulputate
+                                consequat. Integer leo turpis, suscipit
+                                ac venenatis pellentesque, efficitur non
+                                sem. Pellentesque eget vulputate turpis.
+                                Etiam id nibh at elit fermentum
+                                interdum.</p>
                                 <!-- 
                                 Comments can be added like this.
                                 -->
-                                <h2 data-number="4.3" id="results-1"><span class="header-section-number">4.3</span> Results</h2>
-                                <p>These are the results. In vitae odio at libero elementum fermentum vel iaculis enim. Nullam finibus sapien in congue condimentum. Curabitur et ligula et ipsum mollis fringilla.</p>
-                                <h2 data-number="4.4" id="discussion-1"><span class="header-section-number">4.4</span> Discussion</h2>
+                                <h2 data-number="6.3"
+                                id="results-1"><span
+                                class="header-section-number">6.3</span>
+                                Results</h2>
+                                <p>These are the results. In vitae odio
+                                at libero elementum fermentum vel
+                                iaculis enim. Nullam finibus sapien in
+                                congue condimentum. Curabitur et ligula
+                                et ipsum mollis fringilla.</p>
+                                <h2 data-number="6.4"
+                                id="discussion-1"><span
+                                class="header-section-number">6.4</span>
+                                Discussion</h2>
                                 <!--
-                                Figures can be either referenced using @fig:mylabel, and can be auto-completed
-                                to **Fig. number: mylabel** by prefixing with @ for mid-sentence references and * for the start of sentences. See https://github.com/tomduck/pandoc-fignos
+                                Figures can be either referenced using @fig:mylabel. See https://lierdakil.github.io/pandoc-crossref/
                                 -->
-                                <p>Fig. <a href="#fig:my_fig">1</a> shows how to add a figure. Donec ut lacinia nibh. Nam tincidunt augue et tristique cursus. Vestibulum sagittis odio nisl, a malesuada turpis blandit quis. Cras ultrices metus tempor laoreet sodales. Nam molestie ipsum ac imperdiet laoreet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
+                                <p>Figure 1 shows how to add a figure.
+                                Donec ut lacinia nibh. Nam tincidunt
+                                augue et tristique cursus. Vestibulum
+                                sagittis odio nisl, a malesuada turpis
+                                blandit quis. Cras ultrices metus tempor
+                                laoreet sodales. Nam molestie ipsum ac
+                                imperdiet laoreet. Pellentesque habitant
+                                morbi tristique senectus et netus et
+                                malesuada fames ac turpis egestas.</p>
                                 <!-- 
                                 Figures can be added with the following syntax:
-                                ![main_text_caption](source/figures/my_image.pdf "short_caption(optional)"){#fig:mylabel}{ width=50% }
+                                ![main_text_caption](source/figures/my_image.pdf ){#fig:mylabel width=50% short-caption="short caption"}
 
                                 For details on setting attributes like width and height, see:
                                 http://pandoc.org/MANUAL.html#extension-link_attributes
                                 -->
-                                <div id="fig:my_fig" class="fignos">
-                                <figure>
-                                <embed src="source/figures/example_figure.pdf" style="width:100.0%" /><figcaption aria-hidden="true"><span>Figure 1:</span> RV Calypso is a former British Royal Navy minesweeper converted into a research vessel for the oceanographic researcher Jacques-Yves Cousteau. It was equipped with a mobile laboratory for underwater field research.</figcaption>
+                                <figure id="fig:my_fig">
+                                <embed
+                                src="source/figures/example_figure.pdf"
+                                style="width:100.0%"
+                                data-short-caption="Figure short caption" />
+                                <figcaption>Figure 1: RV Calypso is a
+                                former British Royal Navy minesweeper
+                                converted into a research vessel for the
+                                oceanographic researcher Jacques-Yves
+                                Cousteau. It was equipped with a mobile
+                                laboratory for underwater field
+                                research.</figcaption>
                                 </figure>
-                                </div>
-                                <h2 data-number="4.5" id="conclusion-2"><span class="header-section-number">4.5</span> Conclusion</h2>
-                                <p>This is the conclusion to the chapter. Quisque nec purus a quam consectetur volutpat. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In lorem justo, convallis quis lacinia eget, laoreet eu metus. Fusce blandit tellus tellus. Curabitur nec cursus odio. Quisque tristique eros nulla, vitae finibus lorem aliquam quis. Interdum et malesuada fames ac ante ipsum primis in faucibus.</p>
+                                <h2 data-number="6.5"
+                                id="conclusion-2"><span
+                                class="header-section-number">6.5</span>
+                                Conclusion</h2>
+                                <p>This is the conclusion to the
+                                chapter. Quisque nec purus a quam
+                                consectetur volutpat. Cum sociis natoque
+                                penatibus et magnis dis parturient
+                                montes, nascetur ridiculus mus. In lorem
+                                justo, convallis quis lacinia eget,
+                                laoreet eu metus. Fusce blandit tellus
+                                tellus. Curabitur nec cursus odio.
+                                Quisque tristique eros nulla, vitae
+                                finibus lorem aliquam quis. Interdum et
+                                malesuada fames ac ante ipsum primis in
+                                faucibus.</p>
                                 <!--
                                 Below is an example that does not utilize the shortcaption feature, as it already fits neatly on a line. Note that multiple file formats are acceptable for sources (jpg, tiff, pdf, etc.)
                                 -->
-                                <div id="fig:other_fig" class="fignos">
-                                <figure>
-                                <img src="source/figures/full_caption_example.jpg" style="width:100.0%" alt="Figure 2: This is not a boat" /><figcaption aria-hidden="true"><span>Figure 2:</span> This is not a boat</figcaption>
+                                <figure id="fig:other_fig">
+                                <img
+                                src="source/figures/full_caption_example.jpg"
+                                style="width:100.0%"
+                                alt="This is not a boat" />
+                                <figcaption>Figure 2: This is not a
+                                boat</figcaption>
                                 </figure>
-                                </div>
-                                <h1 data-number="5" id="research-containing-a-table"><span class="header-section-number">5</span> Research containing a table</h1>
-                                <h2 data-number="5.1" id="introduction-3"><span class="header-section-number">5.1</span> Introduction</h2>
-                                <p>This is the introduction. Phasellus non purus id mauris aliquam rutrum vitae quis tellus. Maecenas rhoncus ligula nulla, fringilla placerat mi consectetur eu. Aenean nec metus ac est ornare posuere. Nunc ipsum lacus, gravida commodo turpis quis, rutrum eleifend erat. Pellentesque id lorem eget ante porta tincidunt nec nec tellus.</p>
-                                <h2 data-number="5.2" id="method-2"><span class="header-section-number">5.2</span> Method</h2>
-                                <p>Vivamus consectetur, velit in congue lobortis, massa massa lacinia urna, sollicitudin semper ipsum augue quis tortor. Donec quis nisl at arcu volutpat ultrices. Maecenas ex nibh, consequat ac blandit sit amet, molestie in odio. Morbi finibus libero et nisl dignissim, at ultricies ligula pulvinar.</p>
-                                <h3 data-number="5.2.1" id="subsection-1-1"><span class="header-section-number">5.2.1</span> Subsection 1</h3>
-                                <p>This is the first part of the methodology. Integer leo erat, commodo in lacus vel, egestas varius elit. Nulla eget magna quam. Nullam sollicitudin dolor ut ipsum varius tincidunt. Duis dignissim massa in ipsum accumsan imperdiet. Maecenas suscipit sapien sed dui pharetra blandit. Morbi fermentum est vel quam pretium maximus.</p>
-                                <h3 data-number="5.2.2" id="subsection-2-2"><span class="header-section-number">5.2.2</span> Subsection 2</h3>
-                                <p>This is the second part of the methodology. Nullam accumsan condimentum eros eu volutpat. Maecenas quis ligula tempor, interdum ante sit amet, aliquet sem. Fusce tellus massa, blandit id tempus at, cursus in tortor. Nunc nec volutpat ante. Phasellus dignissim ut lectus quis porta. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                                <h1 data-number="7"
+                                id="sec:research-table"><span
+                                class="header-section-number">7</span>
+                                Research containing a table</h1>
+                                <h2 data-number="7.1"
+                                id="introduction-3"><span
+                                class="header-section-number">7.1</span>
+                                Introduction</h2>
+                                <p>This is the introduction. Phasellus
+                                non purus id mauris aliquam rutrum vitae
+                                quis tellus. Maecenas rhoncus ligula
+                                nulla, fringilla placerat mi consectetur
+                                eu. Aenean nec metus ac est ornare
+                                posuere. Nunc ipsum lacus, gravida
+                                commodo turpis quis, rutrum eleifend
+                                erat. Pellentesque id lorem eget ante
+                                porta tincidunt nec nec tellus.</p>
+                                <h2 data-number="7.2"
+                                id="method-2"><span
+                                class="header-section-number">7.2</span>
+                                Method</h2>
+                                <p>Vivamus consectetur, velit in congue
+                                lobortis, massa massa lacinia urna,
+                                sollicitudin semper ipsum augue quis
+                                tortor. Donec quis nisl at arcu volutpat
+                                ultrices. Maecenas ex nibh, consequat ac
+                                blandit sit amet, molestie in odio.
+                                Morbi finibus libero et nisl dignissim,
+                                at ultricies ligula pulvinar.</p>
+                                <h3 data-number="7.2.1"
+                                id="subsection-1-1"><span
+                                class="header-section-number">7.2.1</span>
+                                Subsection 1</h3>
+                                <p>This is the first part of the
+                                methodology. Integer leo erat, commodo
+                                in lacus vel, egestas varius elit. Nulla
+                                eget magna quam. Nullam sollicitudin
+                                dolor ut ipsum varius tincidunt. Duis
+                                dignissim massa in ipsum accumsan
+                                imperdiet. Maecenas suscipit sapien sed
+                                dui pharetra blandit. Morbi fermentum
+                                est vel quam pretium maximus.</p>
+                                <h3 data-number="7.2.2"
+                                id="subsection-2-2"><span
+                                class="header-section-number">7.2.2</span>
+                                Subsection 2</h3>
+                                <p>This is the second part of the
+                                methodology. Nullam accumsan condimentum
+                                eros eu volutpat. Maecenas quis ligula
+                                tempor, interdum ante sit amet, aliquet
+                                sem. Fusce tellus massa, blandit id
+                                tempus at, cursus in tortor. Nunc nec
+                                volutpat ante. Phasellus dignissim ut
+                                lectus quis porta. Lorem ipsum dolor sit
+                                amet, consectetur adipiscing elit.</p>
                                 <!-- 
                                 Comments can be added like this.
                                 -->
-                                <h2 data-number="5.3" id="results-2"><span class="header-section-number">5.3</span> Results</h2>
+                                <h2 data-number="7.3"
+                                id="results-2"><span
+                                class="header-section-number">7.3</span>
+                                Results</h2>
                                 <!-- Table formatting works same as figure formatting -->
-                                <p>Table <a href="#tbl:random">1</a> shows us how to add a table. Integer tincidunt sed nisl eget pellentesque. Mauris eleifend, nisl non lobortis fringilla, sapien eros aliquet orci, vitae pretium massa neque eu turpis. Pellentesque tincidunt aliquet volutpat. Ut ornare dui id ex sodales laoreet.</p>
+                                <p>Table <strong>¿tbl:random?</strong>
+                                shows us how to add a table. Integer
+                                tincidunt sed nisl eget pellentesque.
+                                Mauris eleifend, nisl non lobortis
+                                fringilla, sapien eros aliquet orci,
+                                vitae pretium massa neque eu turpis.
+                                Pellentesque tincidunt aliquet volutpat.
+                                Ut ornare dui id ex sodales laoreet.</p>
                                 <!-- Force the table onto a newpage -->
-                                <div id="tbl:random" class="tablenos">
-                                <table id="tbl:random">
-                                <caption><span>Table 1:</span> Important data for various land masses. </caption>
+                                <table>
+                                <caption>Important data for various land
+                                masses. <span id="tbl:random"
+                                data-short-caption="Table short caption"></span></caption>
                                 <colgroup>
                                 <col style="width: 15%" />
                                 <col style="width: 9%" />
@@ -460,133 +1029,339 @@
                                 </colgroup>
                                 <thead>
                                 <tr class="header">
-                                <th style="text-align: left;">Landmass</th>
-                                <th style="text-align: center;">% stuff</th>
-                                <th style="text-align: center;">Number of Owls</th>
-                                <th style="text-align: center;">Dolphins per Capita</th>
-                                <th style="text-align: center;">How Many Foos</th>
-                                <th style="text-align: center;">How Many Bars</th>
-                                <th style="text-align: center;">Forbidden Float</th>
+                                <th
+                                style="text-align: left;">Landmass</th>
+                                <th style="text-align: center;">%
+                                stuff</th>
+                                <th style="text-align: center;">Number
+                                of Owls</th>
+                                <th style="text-align: center;">Dolphins
+                                per Capita</th>
+                                <th style="text-align: center;">How Many
+                                Foos</th>
+                                <th style="text-align: center;">How Many
+                                Bars</th>
+                                <th
+                                style="text-align: center;">Forbidden
+                                Float</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 <tr class="odd">
-                                <td style="text-align: left;">North America</td>
+                                <td style="text-align: left;">North
+                                America</td>
                                 <td style="text-align: center;">94%</td>
-                                <td style="text-align: center;">20,028</td>
-                                <td style="text-align: center;">17,465</td>
-                                <td style="text-align: center;">12,084</td>
-                                <td style="text-align: center;">20,659</td>
-                                <td style="text-align: center;">1.71</td>
+                                <td
+                                style="text-align: center;">20,028</td>
+                                <td
+                                style="text-align: center;">17,465</td>
+                                <td
+                                style="text-align: center;">12,084</td>
+                                <td
+                                style="text-align: center;">20,659</td>
+                                <td
+                                style="text-align: center;">1.71</td>
                                 </tr>
                                 <tr class="even">
-                                <td style="text-align: left;">Central America</td>
+                                <td style="text-align: left;">Central
+                                America</td>
                                 <td style="text-align: center;">91%</td>
-                                <td style="text-align: center;">6564</td>
-                                <td style="text-align: center;">6350</td>
-                                <td style="text-align: center;">8,189</td>
-                                <td style="text-align: center;">12,012</td>
-                                <td style="text-align: center;">1.52</td>
+                                <td
+                                style="text-align: center;">6564</td>
+                                <td
+                                style="text-align: center;">6350</td>
+                                <td
+                                style="text-align: center;">8,189</td>
+                                <td
+                                style="text-align: center;">12,012</td>
+                                <td
+                                style="text-align: center;">1.52</td>
                                 </tr>
                                 <tr class="odd">
-                                <td style="text-align: left;">South America</td>
+                                <td style="text-align: left;">South
+                                America</td>
                                 <td style="text-align: center;">86%</td>
-                                <td style="text-align: center;">3902</td>
-                                <td style="text-align: center;">4127</td>
-                                <td style="text-align: center;">5,205</td>
-                                <td style="text-align: center;">6,565</td>
-                                <td style="text-align: center;">1.28</td>
+                                <td
+                                style="text-align: center;">3902</td>
+                                <td
+                                style="text-align: center;">4127</td>
+                                <td
+                                style="text-align: center;">5,205</td>
+                                <td
+                                style="text-align: center;">6,565</td>
+                                <td
+                                style="text-align: center;">1.28</td>
                                 </tr>
                                 <tr class="even">
-                                <td style="text-align: left;">Africa</td>
+                                <td
+                                style="text-align: left;">Africa</td>
                                 <td style="text-align: center;">84%</td>
-                                <td style="text-align: center;">2892</td>
-                                <td style="text-align: center;">3175</td>
-                                <td style="text-align: center;">3,862</td>
-                                <td style="text-align: center;">4,248</td>
+                                <td
+                                style="text-align: center;">2892</td>
+                                <td
+                                style="text-align: center;">3175</td>
+                                <td
+                                style="text-align: center;">3,862</td>
+                                <td
+                                style="text-align: center;">4,248</td>
                                 <td style="text-align: center;">1.1</td>
                                 </tr>
                                 <tr class="odd">
-                                <td style="text-align: left;">Europe</td>
+                                <td
+                                style="text-align: left;">Europe</td>
                                 <td style="text-align: center;">92%</td>
-                                <td style="text-align: center;">20,964</td>
-                                <td style="text-align: center;">17,465</td>
-                                <td style="text-align: center;">15,303</td>
-                                <td style="text-align: center;">24,203</td>
-                                <td style="text-align: center;">1.58</td>
+                                <td
+                                style="text-align: center;">20,964</td>
+                                <td
+                                style="text-align: center;">17,465</td>
+                                <td
+                                style="text-align: center;">15,303</td>
+                                <td
+                                style="text-align: center;">24,203</td>
+                                <td
+                                style="text-align: center;">1.58</td>
                                 </tr>
                                 <tr class="even">
                                 <td style="text-align: left;">Asia</td>
                                 <td style="text-align: center;">87%</td>
-                                <td style="text-align: center;">6852</td>
-                                <td style="text-align: center;">6350</td>
-                                <td style="text-align: center;">8,255</td>
-                                <td style="text-align: center;">11,688</td>
-                                <td style="text-align: center;">1.47</td>
+                                <td
+                                style="text-align: center;">6852</td>
+                                <td
+                                style="text-align: center;">6350</td>
+                                <td
+                                style="text-align: center;">8,255</td>
+                                <td
+                                style="text-align: center;">11,688</td>
+                                <td
+                                style="text-align: center;">1.47</td>
                                 </tr>
                                 <tr class="odd">
-                                <td style="text-align: left;">Oceania</td>
+                                <td
+                                style="text-align: left;">Oceania</td>
                                 <td style="text-align: center;">87%</td>
-                                <td style="text-align: center;">4044</td>
-                                <td style="text-align: center;">4127</td>
-                                <td style="text-align: center;">5,540</td>
-                                <td style="text-align: center;">6,972</td>
-                                <td style="text-align: center;">1.28</td>
+                                <td
+                                style="text-align: center;">4044</td>
+                                <td
+                                style="text-align: center;">4127</td>
+                                <td
+                                style="text-align: center;">5,540</td>
+                                <td
+                                style="text-align: center;">6,972</td>
+                                <td
+                                style="text-align: center;">1.28</td>
                                 </tr>
                                 <tr class="even">
-                                <td style="text-align: left;">Antarctica</td>
+                                <td
+                                style="text-align: left;">Antarctica</td>
                                 <td style="text-align: center;">83%</td>
-                                <td style="text-align: center;">2964</td>
-                                <td style="text-align: center;">3175</td>
-                                <td style="text-align: center;">4,402</td>
-                                <td style="text-align: center;">4,941</td>
-                                <td style="text-align: center;">1.13</td>
+                                <td
+                                style="text-align: center;">2964</td>
+                                <td
+                                style="text-align: center;">3175</td>
+                                <td
+                                style="text-align: center;">4,402</td>
+                                <td
+                                style="text-align: center;">4,941</td>
+                                <td
+                                style="text-align: center;">1.13</td>
                                 </tr>
                                 </tbody>
                                 </table>
-                                </div>
-                                <h2 data-number="5.4" id="discussion-2"><span class="header-section-number">5.4</span> Discussion</h2>
-                                <p>This is the discussion. As we saw in Table <a href="#tbl:random">1</a>, many things are true, and other things are not. Etiam sit amet mi eros. Donec vel nisi sed purus gravida fermentum at quis odio. Vestibulum quis nisl sit amet justo maximus molestie. Maecenas vitae arcu erat. Nulla facilisi. Nam pretium mauris eu enim porttitor, a mattis velit dictum. Nulla sit amet ligula non mauris volutpat fermentum quis vitae sapien.</p>
-                                <h2 data-number="5.5" id="conclusion-3"><span class="header-section-number">5.5</span> Conclusion</h2>
-                                <p>This is the conclusion to the chapter. Nullam porta tortor id vehicula interdum. Quisque pharetra, neque ut accumsan suscipit, orci orci commodo tortor, ac finibus est turpis eget justo. Cras sodales nibh nec mauris laoreet iaculis. Morbi volutpat orci felis, id condimentum nulla suscipit eu. Fusce in turpis quis ligula tempus scelerisque eget quis odio. Vestibulum et dolor id erat lobortis ullamcorper quis at sem.</p>
-                                <h1 data-number="6" id="final-research-study"><span class="header-section-number">6</span> Final research study</h1>
-                                <h2 data-number="6.1" id="introduction-4"><span class="header-section-number">6.1</span> Introduction</h2>
-                                <p>This is the introduction. Nunc lorem odio, laoreet eu turpis at, condimentum sagittis diam. Phasellus metus ligula, auctor ac nunc vel, molestie mattis libero. Praesent id posuere ex, vel efficitur nibh. Quisque vestibulum accumsan lacus vitae mattis.</p>
-                                <h2 data-number="6.2" id="method-3"><span class="header-section-number">6.2</span> Method</h2>
-                                <p>In tincidunt viverra dolor, ac pharetra tellus faucibus eget. Pellentesque tempor a enim nec venenatis. Morbi blandit magna imperdiet posuere auctor. Maecenas in maximus est.</p>
-                                <h3 data-number="6.2.1" id="subsection-1-2"><span class="header-section-number">6.2.1</span> Subsection 1</h3>
-                                <p>This is the first part of the methodology. Praesent mollis sem diam, sit amet tristique lacus vulputate quis. Vivamus rhoncus est rhoncus tellus lacinia, a interdum sem egestas. Curabitur quis urna vel quam blandit semper vitae a leo. Nam vel lectus lectus.</p>
-                                <h3 data-number="6.2.2" id="subsection-2-3"><span class="header-section-number">6.2.2</span> Subsection 2</h3>
-                                <p>This is the second part of the methodology. Aenean vel pretium tortor. Aliquam erat volutpat. Quisque quis lobortis mi. Nulla turpis leo, ultrices nec nulla non, ullamcorper laoreet risus.</p>
+                                <h2 data-number="7.4"
+                                id="discussion-2"><span
+                                class="header-section-number">7.4</span>
+                                Discussion</h2>
+                                <p>This is the discussion. As we saw in
+                                Table <strong>¿tbl:random?</strong>,
+                                many things are true, and other things
+                                are not. Etiam sit amet mi eros. Donec
+                                vel nisi sed purus gravida fermentum at
+                                quis odio. Vestibulum quis nisl sit amet
+                                justo maximus molestie. Maecenas vitae
+                                arcu erat. Nulla facilisi. Nam pretium
+                                mauris eu enim porttitor, a mattis velit
+                                dictum. Nulla sit amet ligula non mauris
+                                volutpat fermentum quis vitae
+                                sapien.</p>
+                                <h2 data-number="7.5"
+                                id="conclusion-3"><span
+                                class="header-section-number">7.5</span>
+                                Conclusion</h2>
+                                <p>This is the conclusion to the
+                                chapter. Nullam porta tortor id vehicula
+                                interdum. Quisque pharetra, neque ut
+                                accumsan suscipit, orci orci commodo
+                                tortor, ac finibus est turpis eget
+                                justo. Cras sodales nibh nec mauris
+                                laoreet iaculis. Morbi volutpat orci
+                                felis, id condimentum nulla suscipit eu.
+                                Fusce in turpis quis ligula tempus
+                                scelerisque eget quis odio. Vestibulum
+                                et dolor id erat lobortis ullamcorper
+                                quis at sem.</p>
+                                <h1 data-number="8"
+                                id="sec:research-final"><span
+                                class="header-section-number">8</span>
+                                Final research study</h1>
+                                <h2 data-number="8.1"
+                                id="introduction-4"><span
+                                class="header-section-number">8.1</span>
+                                Introduction</h2>
+                                <p>This is the introduction. Nunc lorem
+                                odio, laoreet eu turpis at, condimentum
+                                sagittis diam. Phasellus metus ligula,
+                                auctor ac nunc vel, molestie mattis
+                                libero. Praesent id posuere ex, vel
+                                efficitur nibh. Quisque vestibulum
+                                accumsan lacus vitae mattis.</p>
+                                <h2 data-number="8.2"
+                                id="method-3"><span
+                                class="header-section-number">8.2</span>
+                                Method</h2>
+                                <p>In tincidunt viverra dolor, ac
+                                pharetra tellus faucibus eget.
+                                Pellentesque tempor a enim nec
+                                venenatis. Morbi blandit magna imperdiet
+                                posuere auctor. Maecenas in maximus
+                                est.</p>
+                                <h3 data-number="8.2.1"
+                                id="subsection-1-2"><span
+                                class="header-section-number">8.2.1</span>
+                                Subsection 1</h3>
+                                <p>This is the first part of the
+                                methodology. Praesent mollis sem diam,
+                                sit amet tristique lacus vulputate quis.
+                                Vivamus rhoncus est rhoncus tellus
+                                lacinia, a interdum sem egestas.
+                                Curabitur quis urna vel quam blandit
+                                semper vitae a leo. Nam vel lectus
+                                lectus.</p>
+                                <h3 data-number="8.2.2"
+                                id="subsection-2-3"><span
+                                class="header-section-number">8.2.2</span>
+                                Subsection 2</h3>
+                                <p>This is the second part of the
+                                methodology. Aenean vel pretium tortor.
+                                Aliquam erat volutpat. Quisque quis
+                                lobortis mi. Nulla turpis leo, ultrices
+                                nec nulla non, ullamcorper laoreet
+                                risus.</p>
                                 <!-- 
                                 Comments can be added like this.
                                 -->
-                                <h2 data-number="6.3" id="results-3"><span class="header-section-number">6.3</span> Results</h2>
-                                <p>These are the results. Curabitur vulputate nisl non ante tincidunt tempor. Aenean porta nisi quam, sed ornare urna congue sed. Curabitur in sapien justo. Quisque pulvinar ullamcorper metus, eu varius mauris pellentesque et. In hac habitasse platea dictumst. Pellentesque nec porttitor libero. Duis et magna a massa lacinia cursus.</p>
-                                <h2 data-number="6.4" id="discussion-3"><span class="header-section-number">6.4</span> Discussion</h2>
-                                <p>This is the discussion. Curabitur gravida nisl id gravida congue. Duis est nisi, sagittis eget accumsan ullamcorper, semper quis turpis. Mauris ultricies diam metus, sollicitudin ultricies turpis lobortis vitae. Ut egestas vehicula enim, porta molestie neque consectetur placerat. Integer iaculis sapien dolor, non porta nibh condimentum ut.</p>
-                                <h2 data-number="6.5" id="conclusion-4"><span class="header-section-number">6.5</span> Conclusion</h2>
-                                <p>This is the conclusion to the chapter. Nulla sed condimentum lectus. Duis sed tempor erat, at cursus lacus. Nam vitae tempus arcu, id vestibulum sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
-                                <h1 data-number="7" id="conclusion-5"><span class="header-section-number">7</span> Conclusion</h1>
+                                <h2 data-number="8.3"
+                                id="results-3"><span
+                                class="header-section-number">8.3</span>
+                                Results</h2>
+                                <p>These are the results. Curabitur
+                                vulputate nisl non ante tincidunt
+                                tempor. Aenean porta nisi quam, sed
+                                ornare urna congue sed. Curabitur in
+                                sapien justo. Quisque pulvinar
+                                ullamcorper metus, eu varius mauris
+                                pellentesque et. In hac habitasse platea
+                                dictumst. Pellentesque nec porttitor
+                                libero. Duis et magna a massa lacinia
+                                cursus.</p>
+                                <h2 data-number="8.4"
+                                id="discussion-3"><span
+                                class="header-section-number">8.4</span>
+                                Discussion</h2>
+                                <p>This is the discussion. Curabitur
+                                gravida nisl id gravida congue. Duis est
+                                nisi, sagittis eget accumsan
+                                ullamcorper, semper quis turpis. Mauris
+                                ultricies diam metus, sollicitudin
+                                ultricies turpis lobortis vitae. Ut
+                                egestas vehicula enim, porta molestie
+                                neque consectetur placerat. Integer
+                                iaculis sapien dolor, non porta nibh
+                                condimentum ut.</p>
+                                <h2 data-number="8.5"
+                                id="conclusion-4"><span
+                                class="header-section-number">8.5</span>
+                                Conclusion</h2>
+                                <p>This is the conclusion to the
+                                chapter. Nulla sed condimentum lectus.
+                                Duis sed tempor erat, at cursus lacus.
+                                Nam vitae tempus arcu, id vestibulum
+                                sapien. Cum sociis natoque penatibus et
+                                magnis dis parturient montes, nascetur
+                                ridiculus mus.</p>
+                                <h1 data-number="9"
+                                id="sec:conclusion"><span
+                                class="header-section-number">9</span>
+                                Conclusion</h1>
                                 <!-- 
                                 A chapter that concludes the thesis by summarising the learning points
                                 and outlining future areas for research
                                 -->
-                                <h2 data-number="7.1" id="thesis-summary"><span class="header-section-number">7.1</span> Thesis summary</h2>
-                                <p>In summary, pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc eleifend, ex a luctus porttitor, felis ex suscipit tellus, ut sollicitudin sapien purus in libero. Nulla blandit eget urna vel tempus. Praesent fringilla dui sapien, sit amet egestas leo sollicitudin at.</p>
-                                <h2 data-number="7.2" id="future-work"><span class="header-section-number">7.2</span> Future work</h2>
-                                <p>There are several potential directions for extending this thesis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam gravida ipsum at tempor tincidunt. Aliquam ligula nisl, blandit et dui eu, eleifend tempus nibh. Nullam eleifend sapien eget ante hendrerit commodo. Pellentesque pharetra erat sit amet dapibus scelerisque.</p>
-                                <p>Vestibulum suscipit tellus risus, faucibus vulputate orci lobortis eget. Nunc varius sem nisi. Nunc tempor magna sapien, euismod blandit elit pharetra sed. In dapibus magna convallis lectus sodales, a consequat sem euismod. Curabitur in interdum purus. Integer ultrices laoreet aliquet. Nulla vel dapibus urna. Nunc efficitur erat ac nisi auctor sodales.</p>
-                                <h1 class="unnumbered" id="appendix-1-some-extra-stuff">Appendix 1: Some extra stuff</h1>
+                                <h2 data-number="9.1"
+                                id="thesis-summary"><span
+                                class="header-section-number">9.1</span>
+                                Thesis summary</h2>
+                                <p>In summary, pellentesque habitant
+                                morbi tristique senectus et netus et
+                                malesuada fames ac turpis egestas. Nunc
+                                eleifend, ex a luctus porttitor, felis
+                                ex suscipit tellus, ut sollicitudin
+                                sapien purus in libero. Nulla blandit
+                                eget urna vel tempus. Praesent fringilla
+                                dui sapien, sit amet egestas leo
+                                sollicitudin at.</p>
+                                <h2 data-number="9.2"
+                                id="future-work"><span
+                                class="header-section-number">9.2</span>
+                                Future work</h2>
+                                <p>There are several potential
+                                directions for extending this thesis.
+                                Lorem ipsum dolor sit amet, consectetur
+                                adipiscing elit. Aliquam gravida ipsum
+                                at tempor tincidunt. Aliquam ligula
+                                nisl, blandit et dui eu, eleifend tempus
+                                nibh. Nullam eleifend sapien eget ante
+                                hendrerit commodo. Pellentesque pharetra
+                                erat sit amet dapibus scelerisque.</p>
+                                <p>Vestibulum suscipit tellus risus,
+                                faucibus vulputate orci lobortis eget.
+                                Nunc varius sem nisi. Nunc tempor magna
+                                sapien, euismod blandit elit pharetra
+                                sed. In dapibus magna convallis lectus
+                                sodales, a consequat sem euismod.
+                                Curabitur in interdum purus. Integer
+                                ultrices laoreet aliquet. Nulla vel
+                                dapibus urna. Nunc efficitur erat ac
+                                nisi auctor sodales.</p>
+                                <h1 class="unnumbered"
+                                id="appendix-1-some-extra-stuff">Appendix
+                                1: Some extra stuff</h1>
                                 <!-- 
                                 This could be a list of papers by the author for example 
                                 -->
-                                <p>Add appendix 1 here. Vivamus hendrerit rhoncus interdum. Sed ullamcorper et augue at porta. Suspendisse facilisis imperdiet urna, eu pellentesque purus suscipit in. Integer dignissim mattis ex aliquam blandit. Curabitur lobortis quam varius turpis ultrices egestas.</p>
-                                <h1 class="unnumbered" id="appendix-2-some-more-extra-stuff">Appendix 2: Some more extra stuff</h1>
+                                <p>Add appendix 1 here. Vivamus
+                                hendrerit rhoncus interdum. Sed
+                                ullamcorper et augue at porta.
+                                Suspendisse facilisis imperdiet urna, eu
+                                pellentesque purus suscipit in. Integer
+                                dignissim mattis ex aliquam blandit.
+                                Curabitur lobortis quam varius turpis
+                                ultrices egestas.</p>
+                                <h1 class="unnumbered"
+                                id="appendix-2-some-more-extra-stuff">Appendix
+                                2: Some more extra stuff</h1>
                                 <!-- 
                                 This could include extra figures or raw data
                                 -->
-                                <p>Add appendix 2 here. Aliquam rhoncus mauris ac neque imperdiet, in mattis eros aliquam. Etiam sed massa et risus posuere rutrum vel et mauris. Integer id mauris sed arcu venenatis finibus. Etiam nec hendrerit purus, sed cursus nunc. Pellentesque ac luctus magna. Aenean non posuere enim, nec hendrerit lacus. Etiam lacinia facilisis tempor. Aenean dictum nunc id felis rhoncus aliquam.</p>
+                                <p>Add appendix 2 here. Aliquam rhoncus
+                                mauris ac neque imperdiet, in mattis
+                                eros aliquam. Etiam sed massa et risus
+                                posuere rutrum vel et mauris. Integer id
+                                mauris sed arcu venenatis finibus. Etiam
+                                nec hendrerit purus, sed cursus nunc.
+                                Pellentesque ac luctus magna. Aenean non
+                                posuere enim, nec hendrerit lacus. Etiam
+                                lacinia facilisis tempor. Aenean dictum
+                                nunc id felis rhoncus aliquam.</p>
                                 <!-- 
                                 Do not edit this page.
 
@@ -594,10 +1369,18 @@
 
                                 ...which you should create using your reference manager.
                                 -->
-                                <h1 class="unnumbered" id="references">References</h1>
-                                <div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-                                <div id="ref-Cousteau1963" class="csl-entry" role="doc-biblioentry">
-                                Cousteau Jacques &amp; Dugan James, 1963. <em><span class="nocase">The Living Sea: by Jacques-Yves Cousteau</span></em>, London: Hamish Hamilton.
+                                <h1 class="unnumbered"
+                                id="references">References</h1>
+                                <div id="refs"
+                                class="references csl-bib-body hanging-indent"
+                                role="list">
+                                <div id="ref-Cousteau1963"
+                                class="csl-entry" role="listitem">
+                                Cousteau Jacques &amp; Dugan James,
+                                1963. <em><span class="nocase">The
+                                Living Sea: by Jacques-Yves
+                                Cousteau</span></em>, London: Hamish
+                                Hamilton.
                                 </div>
                                 </div>
             </body>

--- a/output/thesis.tex
+++ b/output/thesis.tex
@@ -33,6 +33,7 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
+\mathbf{
 \else % if luatex or xelatex
   \ifxetex
     \usepackage{mathspec}
@@ -61,7 +62,7 @@
 \newcommand{\AnnotationTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
 \newcommand{\AttributeTok}[1]{\textcolor[rgb]{0.49,0.56,0.16}{#1}}
 \newcommand{\BaseNTok}[1]{\textcolor[rgb]{0.25,0.63,0.44}{#1}}
-\newcommand{\BuiltInTok}[1]{#1}
+\newcommand{\BuiltInTok}[1]{\textcolor[rgb]{0.00,0.50,0.00}{#1}}
 \newcommand{\CharTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{#1}}
 \newcommand{\CommentTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textit{#1}}}
 \newcommand{\CommentVarTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
@@ -74,7 +75,7 @@
 \newcommand{\ExtensionTok}[1]{#1}
 \newcommand{\FloatTok}[1]{\textcolor[rgb]{0.25,0.63,0.44}{#1}}
 \newcommand{\FunctionTok}[1]{\textcolor[rgb]{0.02,0.16,0.49}{#1}}
-\newcommand{\ImportTok}[1]{#1}
+\newcommand{\ImportTok}[1]{\textcolor[rgb]{0.00,0.50,0.00}{\textbf{#1}}}
 \newcommand{\InformationTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
 \newcommand{\KeywordTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{\textbf{#1}}}
 \newcommand{\NormalTok}[1]{#1}
@@ -292,8 +293,47 @@
 \usepackage{bbold}
 \DeclareMathOperator*{\argmin}{\arg\!\min}
 
-% For use of \cref and \Cref used by pandoc secnos
-\usepackage{cleveref}
+% pandoc-crossref definitions
+
+% We add the lines below from pandoc-crossref because we are using the --include-in-header flag
+% see here: https://lierdakil.github.io/pandoc-crossref/#latex-output-and---include-in-header
+% This LaTeX code is obtained by getting pandoc-crossref to dump it
+% see here: https://github.com/lierdakil/pandoc-crossref/issues/326
+
+\makeatletter
+\@ifpackageloaded{subfig}{}{\usepackage{subfig}}
+\@ifpackageloaded{caption}{}{\usepackage{caption}}
+\captionsetup[subfloat]{margin=0.5em}
+\AtBeginDocument{%
+\renewcommand*\figurename{Figure}
+\renewcommand*\tablename{Table}
+}
+\AtBeginDocument{%
+\renewcommand*\listfigurename{List of Figures}
+\renewcommand*\listtablename{List of Tables}
+}
+\newcounter{pandoccrossref@subfigures@footnote@counter}
+\newenvironment{pandoccrossrefsubfigures}{%
+\setcounter{pandoccrossref@subfigures@footnote@counter}{0}
+\begin{figure}\centering%
+\gdef\global@pandoccrossref@subfigures@footnotes{}%
+\DeclareRobustCommand{\footnote}[1]{\footnotemark%
+\stepcounter{pandoccrossref@subfigures@footnote@counter}%
+\ifx\global@pandoccrossref@subfigures@footnotes\empty%
+\gdef\global@pandoccrossref@subfigures@footnotes{{##1}}%
+\else%
+\g@addto@macro\global@pandoccrossref@subfigures@footnotes{, {##1}}%
+\fi}}%
+{\end{figure}%
+\addtocounter{footnote}{-\value{pandoccrossref@subfigures@footnote@counter}}
+\@for\f:=\global@pandoccrossref@subfigures@footnotes\do{\stepcounter{footnote}\footnotetext{\f}}%
+\gdef\global@pandoccrossref@subfigures@footnotes{}}
+\@ifpackageloaded{float}{}{\usepackage{float}}
+\floatstyle{ruled}
+\@ifundefined{c@chapter}{\newfloat{codelisting}{h}{lop}}{\newfloat{codelisting}{h}{lop}[chapter]}
+\floatname{codelisting}{Listing}
+\newcommand*\listoflistings{\listof{codelisting}{List of Listings}}
+\makeatother
 
 \begin{document}
 
@@ -398,6 +438,7 @@ varius, sed finibus turpis placerat.
 \tableofcontents
 
 \newpage
+
 \listoffigures
 
 \newpage
@@ -422,9 +463,8 @@ varius, sed finibus turpis placerat.
 \doublespacing
 \setlength{\parindent}{0.5in}
 
-\hypertarget{introduction-with-a-citation}{%
-\chapter{Introduction, with a
-citation}\label{introduction-with-a-citation}}
+\hypertarget{sec:intro}{%
+\chapter{Introduction, with a citation}\label{sec:intro}}
 
 \hypertarget{background}{%
 \section{Background}\label{background}}
@@ -481,15 +521,14 @@ tempus non risus. Suspendisse ut felis mi.
 
 This is a brief outline of what went into each chapter, and a section
 which shows how to reference headers (which are labelled automatically
-for you). This chapter, \cref{introduction-with-a-citation}, shows how
-to use citations and how to reference section headers.
-\Cref{literature-review-with-maths} shows how use and reference
-equations. \Cref{first-research-study-with-code} shows how to use and
-reference code. \Cref{research-containing-a-figure} shows how to use,
-reference, and resize pdf and jpg figures.
-\Cref{research-containing-a-table} shows how to use and reference
-tables. \Cref{final-research-study} is truly revolutionary (but shows
-nothing functional).
+for you). This chapter, Section~\ref{sec:intro}, shows how to use
+citations and how to reference section headers.
+Section~\ref{sec:lit-review} shows how use and reference equations.
+Section~\ref{sec:research-code} shows how to use and reference code.
+Section~\ref{sec:research-figure} shows how to use, reference, and
+resize pdf and jpg figures. Section~\ref{sec:research-table} shows how
+to use and reference tables. Section~\ref{sec:research-final} is truly
+revolutionary (but shows nothing functional).
 \textbf{\protect\hyperlink{appendix-1-some-extra-stuff}{Appendix 1}}
 shows how to add chapters which are not numbered, and has to be
 referenced manually, as does
@@ -501,9 +540,8 @@ and provide it to \texttt{pandoc} last.
 
 Proin faucibus nibh sit amet augue blandit varius.
 
-\hypertarget{literature-review-with-maths}{%
-\chapter{Literature review, with
-maths}\label{literature-review-with-maths}}
+\hypertarget{sec:lit-review}{%
+\chapter{Literature review, with maths}\label{sec:lit-review}}
 
 \hypertarget{introduction}{%
 \section{Introduction}\label{introduction}}
@@ -522,13 +560,13 @@ quis, vestibulum nec nulla. Aenean nec dapibus in
 mL/min\textsuperscript{-1}. Mathematical formula can be inserted using
 Latex and can be automatically numbered:
 
-\begin{equation}f(x) = ax^3 + bx^2 + cx + d\label{eq:my_equation}\end{equation}
+\begin{equation}\protect\hypertarget{eq:my_equation}{}{f(x) = ax^3 + bx^2 + cx + d}\label{eq:my_equation}\end{equation}
 
 Nunc eleifend, ex a luctus porttitor, felis ex suscipit tellus, ut
 sollicitudin sapien purus in libero. Nulla blandit eget urna vel tempus.
 Praesent fringilla dui sapien, sit amet egestas leo sollicitudin at.
 
-Later on in the text, you can reference Equation \ref{eq:my_equation}
+Later on in the text, you can reference Equation~\ref{eq:my_equation}
 and its mind-blowing ramifications. Pellentesque habitant morbi
 tristique senectus et netus et malesuada fames ac turpis egestas. Sed
 faucibus pulvinar volutpat. Ut semper fringilla erat non dapibus. Nunc
@@ -538,17 +576,17 @@ vitae felis eget purus placerat finibus laoreet ut nibh.
 \section{A complicated math
 equation}\label{a-complicated-math-equation}}
 
-The following raw text in markdown behind Equation
-\ref{eq:my_complicated_equation} shows that you can fall back on
-\LaTeX if it is more convenient for you. Note that this will only be
+The following raw text in markdown behind
+Equation~\ref{eq:my_complicated_equation} shows that you can fall back
+on \LaTeX if it is more convenient for you. Note that this will only be
 rendered in \texttt{thesis.pdf}
 
-\begin{equation}
+\begin{equation}\protect\hypertarget{eq:my_complicated_equation}{}{
 \begin{aligned}
     \hat{\theta}_g = \argmin_{\theta_g} \Big\{ - &\sum^{N}_{n=1}\Big( 1-\mathbb{1}[f(\pmb x^{(n)})]\Big)\log f\Big(\pmb x^{(n)} \\ 
     &+ g(\pmb x^{(n)};\theta_g)\Big) + \lambda|g(\pmb x^{(n)};\theta_g)|_2 \Big\} \ ,
 \end{aligned}
-\label{eq:my_complicated_equation}\end{equation}
+}\label{eq:my_complicated_equation}\end{equation}
 
 \hypertarget{conclusion}{%
 \section{Conclusion}\label{conclusion}}
@@ -568,9 +606,8 @@ malesuada fames ac turpis egestas.
   third item in the list
 \end{itemize}
 
-\hypertarget{first-research-study-with-code}{%
-\chapter{First research study, with
-code}\label{first-research-study-with-code}}
+\hypertarget{sec:research-code}{%
+\chapter{First research study, with code}\label{sec:research-code}}
 
 \hypertarget{introduction-1}{%
 \section{Introduction}\label{introduction-1}}
@@ -588,9 +625,9 @@ Suspendisse iaculis in lacus ut dignissim. Cras dignissim dictum
 eleifend. Suspendisse potenti. Suspendisse et nisi suscipit, vestibulum
 est at, maximus sapien. Sed ut diam tortor.
 
-\hypertarget{subsection-1-with-example-code-block}{%
+\hypertarget{sec:subsec-code}{%
 \subsection{Subsection 1 with example code
-block}\label{subsection-1-with-example-code-block}}
+block}\label{sec:subsec-code}}
 
 This is the first part of the methodology. Cras porta dui a dolor
 tincidunt placerat. Cras scelerisque sem et malesuada vestibulum.
@@ -602,6 +639,12 @@ blandit.
 For syntax highlighting in code blocks, add three ```'' characters
 before and after a code block:
 
+\begin{codelisting}
+
+\caption{Code caption}
+
+\hypertarget{lst:code}{%
+\label{lst:code}}%
 \begin{Shaded}
 \begin{Highlighting}[]
 \NormalTok{mood }\OperatorTok{=} \StringTok{\textquotesingle{}happy\textquotesingle{}}
@@ -610,15 +653,20 @@ before and after a code block:
 \end{Highlighting}
 \end{Shaded}
 
+\end{codelisting}
+
+You can then reference the code block like this
+(Listing~\ref{lst:code}).
+
 \hypertarget{subsection-2}{%
 \subsection{Subsection 2}\label{subsection-2}}
 
-By running the code in \cref{subsection-1-with-example-code-block}, we
-solved AI completely. This is the second part of the methodology. Proin
-tincidunt odio non sem mollis tristique. Fusce pharetra accumsan
-volutpat. In nec mauris vel orci rutrum dapibus nec ac nibh. Praesent
-malesuada sagittis nulla, eget commodo mauris ultricies eget.
-Suspendisse iaculis finibus ligula.
+By running the code in Section~\ref{sec:subsec-code}, we solved AI
+completely. This is the second part of the methodology. Proin tincidunt
+odio non sem mollis tristique. Fusce pharetra accumsan volutpat. In nec
+mauris vel orci rutrum dapibus nec ac nibh. Praesent malesuada sagittis
+nulla, eget commodo mauris ultricies eget. Suspendisse iaculis finibus
+ligula.
 
 \hypertarget{results}{%
 \section{Results}\label{results}}
@@ -644,9 +692,8 @@ venenatis tellus venenatis at. Etiam ornare, est sed lacinia elementum,
 lectus diam tempor leo, sit amet elementum ex elit id ex. Ut ac viverra
 turpis. Quisque in nisl auctor, ornare dui ac, consequat tellus.
 
-\hypertarget{research-containing-a-figure}{%
-\chapter{Research containing a
-figure}\label{research-containing-a-figure}}
+\hypertarget{sec:research-figure}{%
+\chapter{Research containing a figure}\label{sec:research-figure}}
 
 \hypertarget{introduction-2}{%
 \section{Introduction}\label{introduction-2}}
@@ -692,16 +739,22 @@ ligula et ipsum mollis fringilla.
 \hypertarget{discussion-1}{%
 \section{Discussion}\label{discussion-1}}
 
-Fig. \ref{fig:my_fig} shows how to add a figure. Donec ut lacinia nibh.
-Nam tincidunt augue et tristique cursus. Vestibulum sagittis odio nisl,
-a malesuada turpis blandit quis. Cras ultrices metus tempor laoreet
-sodales. Nam molestie ipsum ac imperdiet laoreet. Pellentesque habitant
-morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+Figure~\ref{fig:my_fig} shows how to add a figure. Donec ut lacinia
+nibh. Nam tincidunt augue et tristique cursus. Vestibulum sagittis odio
+nisl, a malesuada turpis blandit quis. Cras ultrices metus tempor
+laoreet sodales. Nam molestie ipsum ac imperdiet laoreet. Pellentesque
+habitant morbi tristique senectus et netus et malesuada fames ac turpis
+egestas.
 
-\begin{figure}[htbp]
+\begin{figure}
+\hypertarget{fig:my_fig}{%
 \centering
-\includegraphics[width=1.0\textwidth]{source/figures/example_figure.pdf}
-\caption[It's a boat]{RV Calypso is a former British Royal Navy minesweeper converted into a research vessel for the oceanographic researcher Jacques-Yves Cousteau. It was equipped with a mobile laboratory for underwater field research.}\label{fig:my_fig}
+\includegraphics[width=1\textwidth,height=\textheight]{source/figures/example_figure.pdf}
+\caption[Figure short caption]{RV Calypso is a former British Royal Navy
+minesweeper converted into a research vessel for the oceanographic
+researcher Jacques-Yves Cousteau. It was equipped with a mobile
+laboratory for underwater field research.}\label{fig:my_fig}
+}
 \end{figure}
 
 \hypertarget{conclusion-2}{%
@@ -723,9 +776,8 @@ faucibus.
 }
 \end{figure}
 
-\hypertarget{research-containing-a-table}{%
-\chapter{Research containing a
-table}\label{research-containing-a-table}}
+\hypertarget{sec:research-table}{%
+\chapter{Research containing a table}\label{sec:research-table}}
 
 \hypertarget{introduction-3}{%
 \section{Introduction}\label{introduction-3}}
@@ -766,7 +818,7 @@ ipsum dolor sit amet, consectetur adipiscing elit.
 \hypertarget{results-2}{%
 \section{Results}\label{results-2}}
 
-Table \ref{tbl:random} shows us how to add a table. Integer tincidunt
+Table~\ref{tbl:random} shows us how to add a table. Integer tincidunt
 sed nisl eget pellentesque. Mauris eleifend, nisl non lobortis
 fringilla, sapien eros aliquet orci, vitae pretium massa neque eu
 turpis. Pellentesque tincidunt aliquet volutpat. Ut ornare dui id ex
@@ -774,172 +826,73 @@ sodales laoreet.
 
 \newpage
 
-\begin{longtable}[]{@{}lcccccc@{}}
-\caption{Important data for various land masses.
-\label{tbl:random}}\tabularnewline
-\toprule
-\begin{minipage}[b]{0.12\columnwidth}\raggedright
-Landmass\strut
-\end{minipage} & \begin{minipage}[b]{0.08\columnwidth}\centering
-\% stuff\strut
-\end{minipage} & \begin{minipage}[b]{0.10\columnwidth}\centering
-Number of Owls\strut
-\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\centering
-Dolphins per Capita\strut
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\centering
-How Many Foos\strut
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\centering
-How Many Bars\strut
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\centering
-Forbidden Float\strut
-\end{minipage}\tabularnewline
-\midrule
+\def\pandoctableshortcapt{Table short caption}
+
+\hypertarget{tbl:random}{}
+\begin{longtable}[]{@{}
+  >{\raggedright\arraybackslash}p{(\columnwidth - 12\tabcolsep) * \real{0.1529}}
+  >{\centering\arraybackslash}p{(\columnwidth - 12\tabcolsep) * \real{0.0941}}
+  >{\centering\arraybackslash}p{(\columnwidth - 12\tabcolsep) * \real{0.1176}}
+  >{\centering\arraybackslash}p{(\columnwidth - 12\tabcolsep) * \real{0.1765}}
+  >{\centering\arraybackslash}p{(\columnwidth - 12\tabcolsep) * \real{0.1529}}
+  >{\centering\arraybackslash}p{(\columnwidth - 12\tabcolsep) * \real{0.1529}}
+  >{\centering\arraybackslash}p{(\columnwidth - 12\tabcolsep) * \real{0.1529}}@{}}
+\caption[Table short caption]{\label{tbl:random}Important data for
+various land masses.}\tabularnewline
+\toprule\noalign{}
+\begin{minipage}[b]{\linewidth}\raggedright
+Landmass
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\% stuff
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+Number of Owls
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+Dolphins per Capita
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+How Many Foos
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+How Many Bars
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+Forbidden Float
+\end{minipage} \\
+\midrule\noalign{}
 \endfirsthead
-\toprule
-\begin{minipage}[b]{0.12\columnwidth}\raggedright
-Landmass\strut
-\end{minipage} & \begin{minipage}[b]{0.08\columnwidth}\centering
-\% stuff\strut
-\end{minipage} & \begin{minipage}[b]{0.10\columnwidth}\centering
-Number of Owls\strut
-\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\centering
-Dolphins per Capita\strut
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\centering
-How Many Foos\strut
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\centering
-How Many Bars\strut
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\centering
-Forbidden Float\strut
-\end{minipage}\tabularnewline
-\midrule
+\toprule\noalign{}
+\begin{minipage}[b]{\linewidth}\raggedright
+Landmass
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\% stuff
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+Number of Owls
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+Dolphins per Capita
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+How Many Foos
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+How Many Bars
+\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+Forbidden Float
+\end{minipage} \\
+\midrule\noalign{}
 \endhead
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-North America\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-94\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-20,028\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-17,465\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-12,084\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-20,659\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.71\strut
-\end{minipage}\tabularnewline
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-Central America\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-91\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-6564\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-6350\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-8,189\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-12,012\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.52\strut
-\end{minipage}\tabularnewline
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-South America\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-86\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-3902\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-4127\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-5,205\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-6,565\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.28\strut
-\end{minipage}\tabularnewline
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-Africa\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-84\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-2892\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-3175\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-3,862\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-4,248\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.1\strut
-\end{minipage}\tabularnewline
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-Europe\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-92\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-20,964\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-17,465\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-15,303\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-24,203\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.58\strut
-\end{minipage}\tabularnewline
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-Asia\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-87\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-6852\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-6350\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-8,255\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-11,688\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.47\strut
-\end{minipage}\tabularnewline
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-Oceania\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-87\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-4044\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-4127\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-5,540\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-6,972\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.28\strut
-\end{minipage}\tabularnewline
-\begin{minipage}[t]{0.12\columnwidth}\raggedright
-Antarctica\strut
-\end{minipage} & \begin{minipage}[t]{0.08\columnwidth}\centering
-83\%\strut
-\end{minipage} & \begin{minipage}[t]{0.10\columnwidth}\centering
-2964\strut
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\centering
-3175\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-4,402\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-4,941\strut
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\centering
-1.13\strut
-\end{minipage}\tabularnewline
-\bottomrule
+\bottomrule\noalign{}
+\endlastfoot
+North America & 94\% & 20,028 & 17,465 & 12,084 & 20,659 & 1.71 \\
+Central America & 91\% & 6564 & 6350 & 8,189 & 12,012 & 1.52 \\
+South America & 86\% & 3902 & 4127 & 5,205 & 6,565 & 1.28 \\
+Africa & 84\% & 2892 & 3175 & 3,862 & 4,248 & 1.1 \\
+Europe & 92\% & 20,964 & 17,465 & 15,303 & 24,203 & 1.58 \\
+Asia & 87\% & 6852 & 6350 & 8,255 & 11,688 & 1.47 \\
+Oceania & 87\% & 4044 & 4127 & 5,540 & 6,972 & 1.28 \\
+Antarctica & 83\% & 2964 & 3175 & 4,402 & 4,941 & 1.13 \\
 \end{longtable}
+
+\let\pandoctableshortcapt\relax
 
 \hypertarget{discussion-2}{%
 \section{Discussion}\label{discussion-2}}
 
-This is the discussion. As we saw in Table \ref{tbl:random}, many things
+This is the discussion. As we saw in Table~\ref{tbl:random}, many things
 are true, and other things are not. Etiam sit amet mi eros. Donec vel
 nisi sed purus gravida fermentum at quis odio. Vestibulum quis nisl sit
 amet justo maximus molestie. Maecenas vitae arcu erat. Nulla facilisi.
@@ -956,8 +909,8 @@ mauris laoreet iaculis. Morbi volutpat orci felis, id condimentum nulla
 suscipit eu. Fusce in turpis quis ligula tempus scelerisque eget quis
 odio. Vestibulum et dolor id erat lobortis ullamcorper quis at sem.
 
-\hypertarget{final-research-study}{%
-\chapter{Final research study}\label{final-research-study}}
+\hypertarget{sec:research-final}{%
+\chapter{Final research study}\label{sec:research-final}}
 
 \hypertarget{introduction-4}{%
 \section{Introduction}\label{introduction-4}}
@@ -1015,8 +968,8 @@ Duis sed tempor erat, at cursus lacus. Nam vitae tempus arcu, id
 vestibulum sapien. Cum sociis natoque penatibus et magnis dis parturient
 montes, nascetur ridiculus mus.
 
-\hypertarget{conclusion-5}{%
-\chapter{Conclusion}\label{conclusion-5}}
+\hypertarget{sec:conclusion}{%
+\chapter{Conclusion}\label{sec:conclusion}}
 
 \hypertarget{thesis-summary}{%
 \section{Thesis summary}\label{thesis-summary}}
@@ -1074,7 +1027,7 @@ Aenean dictum nunc id felis rhoncus aliquam.
 
 \hypertarget{refs}{}
 \begin{CSLReferences}{1}{0}
-\leavevmode\hypertarget{ref-Cousteau1963}{}%
+\leavevmode\vadjust pre{\hypertarget{ref-Cousteau1963}{}}%
 Cousteau Jacques \& Dugan James, 1963. \emph{{The Living Sea: by
 Jacques-Yves Cousteau}}, London: Hamish Hamilton.
 

--- a/source/06_list_of_figures.md
+++ b/source/06_list_of_figures.md
@@ -1,7 +1,7 @@
 \listoffigures
-<!-- 
+<!--
 The \listoffigures will use short captions first, and the whole caption if none is present. To keep this list readable, ensure each figure has a short caption, e.g.
-![main_text_caption](source/figures/my_image.pdf "short caption used in alt text and \listoffigures"){#fig:mylabel}{ width=50% }
+![main_text_caption](source/figures/my_image.pdf ){#fig:mylabel}{ width=50% short-caption="short caption"}
 
 See chapter 4 for more examples.
 -->

--- a/source/07_list_of_tables.md
+++ b/source/07_list_of_tables.md
@@ -3,7 +3,7 @@
 \newpage
 
 <!--
-The \listoffigures will use short captions first, and the whole caption if none is present. To keep this list readable, ensure each figure has a short caption, e.g.
+The \listoftables will use short captions first, and the whole caption if none is present. To keep this list readable, ensure each figure has a short caption, e.g.
 
 +----------+----------+----------+
 |   Test   |  Test2   |  Test3   |

--- a/source/07_list_of_tables.md
+++ b/source/07_list_of_tables.md
@@ -2,5 +2,22 @@
 
 \newpage
 
+<!--
+The \listoffigures will use short captions first, and the whole caption if none is present. To keep this list readable, ensure each figure has a short caption, e.g.
+
++----------+----------+----------+
+|   Test   |  Test2   |  Test3   |
++----------+----------+----------+
+|    20    |    22    |    23    |
++----------+----------+----------+
+|    34    |    35    |    36    |
++----------+----------+----------+
+:  Long caption []{#tbl:tbl_ref short-caption="short caption"}
+
+You MUST include the empty square brackets before the curly brackets.
+
+See chapter 5 for more examples.
+-->
+
 
 

--- a/source/09_chapter_1.md
+++ b/source/09_chapter_1.md
@@ -3,7 +3,7 @@
 \doublespacing
 \setlength{\parindent}{0.5in}
 
-# Introduction, with a citation
+# Introduction, with a citation {#sec:intro}
 
 ## Background
 
@@ -31,13 +31,13 @@ This is a subsection of the middle bit. Quisque sit amet tempus arcu, ac suscipi
 
 ## Summary of chapters
 
-<!-- 
+<!--
 For italic, add _ on either side of the text
 For bold, add ** on either side of the text
 For bold and italic, add _** on either side of the text
 -->
 
-This is a brief outline of what went into each chapter, and a section which shows how to reference headers (which are labelled automatically for you). This chapter, +@sec:introduction-with-a-citation, shows how to use citations and how to reference section headers. \*@sec:literature-review-with-maths shows how use and reference equations. \*@sec:first-research-study-with-code shows how to use and reference code. \*@sec:research-containing-a-figure shows how to use, reference, and resize pdf and jpg figures. \*@sec:research-containing-a-table shows how to use and reference tables. \*@sec:final-research-study is truly revolutionary (but shows nothing functional). **[Appendix 1](#appendix-1-some-extra-stuff)** shows how to add chapters which are not numbered, and has to be referenced manually, as does **[Appendix 2](#appendix-2-some-more-extra-stuff)**. See the base [`README.md`](https://github.com/tompollard/phd_thesis_markdown/blob/master/README.md) for how References are handled - leave `*_references.md` alone, and provide it to `pandoc` last.
+This is a brief outline of what went into each chapter, and a section which shows how to reference headers (which are labelled automatically for you). This chapter, @sec:intro, shows how to use citations and how to reference section headers. @sec:lit-review shows how use and reference equations. @sec:research-code shows how to use and reference code. @sec:research-figure shows how to use, reference, and resize pdf and jpg figures. @sec:research-table shows how to use and reference tables. @sec:research-final is truly revolutionary (but shows nothing functional). **[Appendix 1](#appendix-1-some-extra-stuff)** shows how to add chapters which are not numbered, and has to be referenced manually, as does **[Appendix 2](#appendix-2-some-more-extra-stuff)**. See the base [`README.md`](https://github.com/tompollard/phd_thesis_markdown/blob/master/README.md) for how References are handled - leave `*_references.md` alone, and provide it to `pandoc` last.
 
 Proin faucibus nibh sit amet augue blandit varius.
 

--- a/source/10_chapter_2.md
+++ b/source/10_chapter_2.md
@@ -1,8 +1,8 @@
-# Literature review, with maths
+# Literature review, with maths {#sec:lit-review}
 
 <!--
-After the introductory chapter, it seems fairly common to 
-include a chapter that reviews the literature and 
+After the introductory chapter, it seems fairly common to
+include a chapter that reviews the literature and
 introduces methodology used throughout the thesis.
 -->
 
@@ -13,15 +13,15 @@ This is the introduction. Duis in neque felis. In hac habitasse platea dictumst.
 ## The middle
 
 This is the literature review. Nullam quam odio, volutpat ac ornare quis, vestibulum nec nulla. Aenean nec dapibus in mL/min^-1^. Mathematical formula can be inserted using Latex and can be automatically numbered:
- 
-$f(x) = ax^3 + bx^2 + cx + d$ {#eq:my_equation}
 
-Nunc eleifend, ex a luctus porttitor, felis ex suscipit tellus, ut sollicitudin sapien purus in libero. Nulla blandit eget urna vel tempus. Praesent fringilla dui sapien, sit amet egestas leo sollicitudin at.  
+$$f(x) = ax^3 + bx^2 + cx + d$$ {#eq:my_equation}
 
-Later on in the text, you can reference Equation {!@eq:my_equation} and its mind-blowing ramifications. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed faucibus pulvinar volutpat. Ut semper fringilla erat non dapibus. Nunc vitae felis eget purus placerat finibus laoreet ut nibh.
+Nunc eleifend, ex a luctus porttitor, felis ex suscipit tellus, ut sollicitudin sapien purus in libero. Nulla blandit eget urna vel tempus. Praesent fringilla dui sapien, sit amet egestas leo sollicitudin at.
+
+Later on in the text, you can reference [@eq:my_equation] and its mind-blowing ramifications. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed faucibus pulvinar volutpat. Ut semper fringilla erat non dapibus. Nunc vitae felis eget purus placerat finibus laoreet ut nibh.
 
 ## A complicated math equation
-The following raw text in markdown behind Equation {!@eq:my_complicated_equation} shows that you can fall back on \LaTeX if it is more convenient for you. Note that this will only be rendered in `thesis.pdf`
+The following raw text in markdown behind [@eq:my_complicated_equation] shows that you can fall back on \LaTeX if it is more convenient for you. Note that this will only be rendered in `thesis.pdf`
 
 $$
 \begin{aligned}

--- a/source/11_chapter_3.md
+++ b/source/11_chapter_3.md
@@ -26,7 +26,7 @@ You can then reference the code block like this (@lst:code).
 
 ### Subsection 2
 
-By running the code in +@sec:subsec-code, we solved AI completely. This is the second part of the methodology. Proin tincidunt odio non sem mollis tristique. Fusce pharetra accumsan volutpat. In nec mauris vel orci rutrum dapibus nec ac nibh. Praesent malesuada sagittis nulla, eget commodo mauris ultricies eget. Suspendisse iaculis finibus ligula.
+By running the code in @sec:subsec-code, we solved AI completely. This is the second part of the methodology. Proin tincidunt odio non sem mollis tristique. Fusce pharetra accumsan volutpat. In nec mauris vel orci rutrum dapibus nec ac nibh. Praesent malesuada sagittis nulla, eget commodo mauris ultricies eget. Suspendisse iaculis finibus ligula.
 
 <!-- 
 Comments can be added like this.

--- a/source/11_chapter_3.md
+++ b/source/11_chapter_3.md
@@ -1,4 +1,4 @@
-# First research study, with code
+# First research study, with code {#sec:research-code}
 
 ## Introduction
 
@@ -8,7 +8,7 @@ This is the introduction. Nam mollis congue tortor, sit amet convallis tortor mo
 
 Suspendisse iaculis in lacus ut dignissim. Cras dignissim dictum eleifend. Suspendisse potenti. Suspendisse et nisi suscipit, vestibulum est at, maximus sapien. Sed ut diam tortor.
 
-### Subsection 1 with example code block
+### Subsection 1 with example code block {#sec:subsec-code}
 
 This is the first part of the methodology. Cras porta dui a dolor tincidunt placerat. Cras scelerisque sem et malesuada vestibulum. Vivamus faucibus ligula ac sodales consectetur. Aliquam vel tristique nisl. Aliquam erat volutpat. Pellentesque iaculis enim sit amet posuere facilisis. Integer egestas quam sit amet nunc maximus, id bibendum ex blandit.
 
@@ -20,9 +20,13 @@ if mood == 'happy':
     print("I am a happy robot")
 ```
 
+: Code caption {#lst:code}
+
+You can then reference the code block like this (@lst:code).
+
 ### Subsection 2
 
-By running the code in +@sec:subsection-1-with-example-code-block, we solved AI completely. This is the second part of the methodology. Proin tincidunt odio non sem mollis tristique. Fusce pharetra accumsan volutpat. In nec mauris vel orci rutrum dapibus nec ac nibh. Praesent malesuada sagittis nulla, eget commodo mauris ultricies eget. Suspendisse iaculis finibus ligula.
+By running the code in +@sec:subsec-code, we solved AI completely. This is the second part of the methodology. Proin tincidunt odio non sem mollis tristique. Fusce pharetra accumsan volutpat. In nec mauris vel orci rutrum dapibus nec ac nibh. Praesent malesuada sagittis nulla, eget commodo mauris ultricies eget. Suspendisse iaculis finibus ligula.
 
 <!-- 
 Comments can be added like this.

--- a/source/12_chapter_4.md
+++ b/source/12_chapter_4.md
@@ -1,4 +1,4 @@
-# Research containing a figure
+# Research containing a figure {#sec:research-figure}
 
 ## Introduction
 
@@ -31,17 +31,17 @@ Figures can be either referenced using @fig:mylabel, and can be auto-completed
 to **Fig. number: mylabel** by prefixing with @ for mid-sentence references and * for the start of sentences. See https://github.com/tomduck/pandoc-fignos
 -->
 
-Fig. @fig:my_fig shows how to add a figure. Donec ut lacinia nibh. Nam tincidunt augue et tristique cursus. Vestibulum sagittis odio nisl, a malesuada turpis blandit quis. Cras ultrices metus tempor laoreet sodales. Nam molestie ipsum ac imperdiet laoreet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+@fig:my_fig shows how to add a figure. Donec ut lacinia nibh. Nam tincidunt augue et tristique cursus. Vestibulum sagittis odio nisl, a malesuada turpis blandit quis. Cras ultrices metus tempor laoreet sodales. Nam molestie ipsum ac imperdiet laoreet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
 
 <!-- 
 Figures can be added with the following syntax:
-![main_text_caption](source/figures/my_image.pdf "short_caption(optional)"){#fig:mylabel}{ width=50% }
+![main_text_caption](source/figures/my_image.pdf ){#fig:mylabel width=50% short-caption="short caption"}
 
 For details on setting attributes like width and height, see:
 http://pandoc.org/MANUAL.html#extension-link_attributes
 --> 
 
-![RV Calypso is a former British Royal Navy minesweeper converted into a research vessel for the oceanographic researcher Jacques-Yves Cousteau. It was equipped with a mobile laboratory for underwater field research.](source/figures/example_figure.pdf "It's a boat"){#fig:my_fig width=100%}
+![RV Calypso is a former British Royal Navy minesweeper converted into a research vessel for the oceanographic researcher Jacques-Yves Cousteau. It was equipped with a mobile laboratory for underwater field research.](source/figures/example_figure.pdf){#fig:my_fig width=100% short-caption="Figure short caption"}
 
 ## Conclusion
 

--- a/source/12_chapter_4.md
+++ b/source/12_chapter_4.md
@@ -27,8 +27,7 @@ These are the results. In vitae odio at libero elementum fermentum vel iaculis e
 ## Discussion
 
 <!--
-Figures can be either referenced using @fig:mylabel, and can be auto-completed
-to **Fig. number: mylabel** by prefixing with @ for mid-sentence references and * for the start of sentences. See https://github.com/tomduck/pandoc-fignos
+Figures can be either referenced using @fig:mylabel. See https://lierdakil.github.io/pandoc-crossref/
 -->
 
 @fig:my_fig shows how to add a figure. Donec ut lacinia nibh. Nam tincidunt augue et tristique cursus. Vestibulum sagittis odio nisl, a malesuada turpis blandit quis. Cras ultrices metus tempor laoreet sodales. Nam molestie ipsum ac imperdiet laoreet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.

--- a/source/13_chapter_5.md
+++ b/source/13_chapter_5.md
@@ -1,4 +1,4 @@
-# Research containing a table
+# Research containing a table {#sec:research-table}
 
 ## Introduction
 
@@ -24,7 +24,7 @@ Comments can be added like this.
 
 <!-- Table formatting works same as figure formatting -->
 
-Table @tbl:random shows us how to add a table. Integer tincidunt sed nisl eget pellentesque. Mauris eleifend, nisl non lobortis fringilla, sapien eros aliquet orci, vitae pretium massa neque eu turpis. Pellentesque tincidunt aliquet volutpat. Ut ornare dui id ex sodales laoreet.
+[@tbl:random] shows us how to add a table. Integer tincidunt sed nisl eget pellentesque. Mauris eleifend, nisl non lobortis fringilla, sapien eros aliquet orci, vitae pretium massa neque eu turpis. Pellentesque tincidunt aliquet volutpat. Ut ornare dui id ex sodales laoreet.
 
 <!-- Force the table onto a newpage -->
 
@@ -54,11 +54,11 @@ Oceania      87%     4044         4127         5,540        6,972        1.28
 Antarctica    83%     2964         3175         4,402        4,941        1.13
 -----------------------------------------------------------------------------------
 
-Table: Important data for various land masses. {#tbl:random}
+: Important data for various land masses. []{#tbl:random short-caption="Table short caption"}
 
 ## Discussion
 
-This is the discussion. As we saw in Table @tbl:random, many things are true, and other things are not. Etiam sit amet mi eros. Donec vel nisi sed purus gravida fermentum at quis odio. Vestibulum quis nisl sit amet justo maximus molestie. Maecenas vitae arcu erat. Nulla facilisi. Nam pretium mauris eu enim porttitor, a mattis velit dictum. Nulla sit amet ligula non mauris volutpat fermentum quis vitae sapien.
+This is the discussion. As we saw in @tbl:random, many things are true, and other things are not. Etiam sit amet mi eros. Donec vel nisi sed purus gravida fermentum at quis odio. Vestibulum quis nisl sit amet justo maximus molestie. Maecenas vitae arcu erat. Nulla facilisi. Nam pretium mauris eu enim porttitor, a mattis velit dictum. Nulla sit amet ligula non mauris volutpat fermentum quis vitae sapien.
 
 ## Conclusion
 

--- a/source/14_chapter_6.md
+++ b/source/14_chapter_6.md
@@ -1,4 +1,4 @@
-# Final research study
+# Final research study {#sec:research-final}
 
 ## Introduction
 

--- a/source/15_conclusion.md
+++ b/source/15_conclusion.md
@@ -1,4 +1,4 @@
-# Conclusion
+# Conclusion {#sec:conclusion}
 
 <!-- 
 A chapter that concludes the thesis by summarising the learning points

--- a/source/metadata.yml
+++ b/source/metadata.yml
@@ -21,4 +21,8 @@ secPrefix:
 tblPrefix:
   - "Table"
   - "Tables"
+lstPrefix:
+  - "Listing"
+  - "Listings"
+codeBlockCaptions: true
 ---

--- a/source/metadata.yml
+++ b/source/metadata.yml
@@ -9,4 +9,16 @@ supervisor:
 - Professor Louis Fage
 - Captain J. Y. Cousteau
 degree: Doctor of Philosophy
+eqnPrefix:
+  - "Equation"
+  - "Equations"
+figPrefix:
+  - "Figure"
+  - "Figures"
+secPrefix:
+  - "Section"
+  - "Sections"
+tblPrefix:
+  - "Table"
+  - "Tables"
 ---

--- a/style/preamble.tex
+++ b/style/preamble.tex
@@ -145,3 +145,44 @@
 
 % For use of \cref and \Cref used by pandoc secnos
 \usepackage{cleveref}
+% pandoc-crossref definitions
+
+% We add the lines below from pandoc-crossref because we are using the --include-in-header flag
+% see here: https://lierdakil.github.io/pandoc-crossref/#latex-output-and---include-in-header
+% This LaTeX code is obtained by getting pandoc-crossref to dump it
+% see here: https://github.com/lierdakil/pandoc-crossref/issues/326
+
+\makeatletter
+\@ifpackageloaded{subfig}{}{\usepackage{subfig}}
+\@ifpackageloaded{caption}{}{\usepackage{caption}}
+\captionsetup[subfloat]{margin=0.5em}
+\AtBeginDocument{%
+\renewcommand*\figurename{Figure}
+\renewcommand*\tablename{Table}
+}
+\AtBeginDocument{%
+\renewcommand*\listfigurename{List of Figures}
+\renewcommand*\listtablename{List of Tables}
+}
+\newcounter{pandoccrossref@subfigures@footnote@counter}
+\newenvironment{pandoccrossrefsubfigures}{%
+\setcounter{pandoccrossref@subfigures@footnote@counter}{0}
+\begin{figure}\centering%
+\gdef\global@pandoccrossref@subfigures@footnotes{}%
+\DeclareRobustCommand{\footnote}[1]{\footnotemark%
+\stepcounter{pandoccrossref@subfigures@footnote@counter}%
+\ifx\global@pandoccrossref@subfigures@footnotes\empty%
+\gdef\global@pandoccrossref@subfigures@footnotes{{##1}}%
+\else%
+\g@addto@macro\global@pandoccrossref@subfigures@footnotes{, {##1}}%
+\fi}}%
+{\end{figure}%
+\addtocounter{footnote}{-\value{pandoccrossref@subfigures@footnote@counter}}
+\@for\f:=\global@pandoccrossref@subfigures@footnotes\do{\stepcounter{footnote}\footnotetext{\f}}%
+\gdef\global@pandoccrossref@subfigures@footnotes{}}
+\@ifpackageloaded{float}{}{\usepackage{float}}
+\floatstyle{ruled}
+\@ifundefined{c@chapter}{\newfloat{codelisting}{h}{lop}}{\newfloat{codelisting}{h}{lop}[chapter]}
+\floatname{codelisting}{Listing}
+\newcommand*\listoflistings{\listof{codelisting}{List of Listings}}
+\makeatother

--- a/style/preamble.tex
+++ b/style/preamble.tex
@@ -143,8 +143,6 @@
 \usepackage{bbold}
 \DeclareMathOperator*{\argmin}{\arg\!\min}
 
-% For use of \cref and \Cref used by pandoc secnos
-\usepackage{cleveref}
 % pandoc-crossref definitions
 
 % We add the lines below from pandoc-crossref because we are using the --include-in-header flag


### PR DESCRIPTION
This PR:

1. Migrates cross-referencing to `pandoc-crossref`
2. Adds Lua filters that enable short captions for figures and tables (i.e. shorter captions for use in TeX/PDF List of Figures/Tables)
3. Updates source/*.md files to match `pandoc-crossref` + short-caption syntax
4. Provides examples of `pandoc-crossref` customisation in source/metadata.yaml]
5. Updates README to reflect changes above (plus some other opinionated changes, happy for those to be changed)

**Provisos**:
1. The `table-short-captions` filter must be listed as a flag (i.e. run) before `pandoc-crossref`
2. `pandoc-crossref` uses the `--include-in-header` option. That is, specifying this overwrites definitions created by `pandoc-crossref`. To navigate this, the definitions have been manually added into `style/preamble.tex`. 

- [x] Changing `xnos` flags to `crossref` in Makefile
- [x] Adding working `figure-short-captions` and `table-short-captions` Lua filters, and calling these in Makefile
- [x] Changing referencing in the sample text to conform with `crossref` style
- [X] Updating README
  - [X] Require pandoc 3.1+

closes #53, closes #68, closes #91, closes #107, closes #116, closes #117 
